### PR TITLE
implement account setup pages

### DIFF
--- a/lib/Account_Login.dart
+++ b/lib/Account_Login.dart
@@ -1,0 +1,188 @@
+import 'package:carriage_rider/Account_Name.dart';
+import 'package:flutter/material.dart';
+import 'package:carriage_rider/Home.dart';
+import 'package:url_launcher/url_launcher.dart' as UrlLauncher;
+import 'package:carriage_rider/AuthProvider.dart';
+import 'RiderProvider.dart';
+import 'package:provider/provider.dart';
+import 'package:carriage_rider/app_config.dart';
+
+class AccountLogin extends StatefulWidget {
+  @override
+  _AccountLoginState createState() => _AccountLoginState();
+}
+
+class _AccountLoginState extends State<AccountLogin> {
+  final _formKey = GlobalKey<FormState>();
+  FocusNode focusNode = FocusNode();
+  TextEditingController emailCtrl = TextEditingController();
+  TextEditingController passCtrl = TextEditingController();
+
+  Widget _buildEmailField() {
+    return TextFormField(
+      controller: emailCtrl,
+      focusNode: focusNode,
+      decoration: InputDecoration(
+        labelText: 'Email',
+        hintText: 'Email',
+        hintStyle: TextStyle(color: Colors.white),
+        labelStyle: TextStyle(color: Colors.white),
+        enabledBorder: UnderlineInputBorder(
+          borderSide: BorderSide(color: Colors.white),
+        ),
+      ),
+      textInputAction: TextInputAction.next,
+      validator: (input) {
+        if (input.isEmpty) {
+          return 'Please enter your email';
+        }
+        return null;
+      },
+      style: TextStyle(color: Colors.white, fontSize: 15),
+      onFieldSubmitted: (value) => FocusScope.of(context).nextFocus(),
+    );
+  }
+
+  Widget _buildPasswordField() {
+    return TextFormField(
+      controller: passCtrl,
+      obscureText: true,
+      decoration: InputDecoration(
+        labelText: 'Password',
+        hintText: 'Password',
+        hintStyle: TextStyle(color: Colors.white),
+        labelStyle: TextStyle(color: Colors.white),
+        enabledBorder: UnderlineInputBorder(
+          borderSide: BorderSide(color: Colors.white),
+        ),
+      ),
+      textInputAction: TextInputAction.done,
+      validator: (input) {
+        if (input.isEmpty) {
+          return 'Please enter your password';
+        }
+        return null;
+      },
+      style: TextStyle(color: Colors.white, fontSize: 15),
+    );
+  }
+
+  final cancelStyle = TextStyle(
+    color: Colors.white,
+    fontWeight: FontWeight.w100,
+    fontSize: 15,
+  );
+
+  final titleStyle = TextStyle(
+    color: Colors.white,
+    fontWeight: FontWeight.w400,
+    fontSize: 25,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    RiderProvider riderProvider = Provider.of<RiderProvider>(context);
+    AuthProvider authProvider = Provider.of(context);
+    return Scaffold(
+        resizeToAvoidBottomInset: false,
+        backgroundColor: Colors.black,
+        body: Container(
+          margin: EdgeInsets.only(top: 50.0, left: 20.0, right: 20.0),
+          child: Column(
+            children: <Widget>[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: <Widget>[
+                  Container(
+                    child: InkWell(
+                      child: Text("Cancel", style: cancelStyle),
+                      onTap: () {
+                        Navigator.pop(
+                            context,
+                            new MaterialPageRoute(
+                                builder: (context) => Home()));
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 50.0),
+              Row(
+                children: <Widget>[
+                  Text("Welcome to Carriage", style: titleStyle),
+                ],
+              ),
+              SizedBox(height: 15.0),
+              Row(children: <Widget>[
+                Text("Sign in using your Cornell email",
+                    style: TextStyle(color: Colors.grey, fontSize: 15)),
+              ]),
+              SizedBox(height: 40.0),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: <Widget>[
+                    _buildEmailField(),
+                    SizedBox(height: 20.0),
+                    _buildPasswordField(),
+                    SizedBox(height: 10.0)
+                  ],
+                ),
+              ),
+              SizedBox(height: 10.0),
+              Row(children: <Widget>[
+                GestureDetector(
+                    onTap: () => _launchURL(),
+                    child: Text(
+                      "Forgot your password?",
+                      style: TextStyle(
+                          color: Colors.white,
+                          decoration: TextDecoration.underline),
+                    )),
+              ]),
+              Expanded(
+                child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 20.0),
+                      child: ButtonTheme(
+                        minWidth: MediaQuery.of(context).size.width * 0.8,
+                        height: 45.0,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(3)),
+                        child: RaisedButton(
+                          onPressed: () {
+                            if (_formKey.currentState.validate()) {
+                              _formKey.currentState.save();
+                              riderProvider.setEmail(AppConfig.of(context),
+                                  authProvider, emailCtrl.text);
+                              Navigator.pop(context);
+                            }
+                            Navigator.push(
+                                context,
+                                new MaterialPageRoute(
+                                    builder: (context) => AccountName()));
+                          },
+                          elevation: 3.0,
+                          color: Colors.white,
+                          textColor: Colors.black,
+                          child: Text('Sign In'),
+                        ),
+                      ),
+                    )),
+              )
+            ],
+          ),
+        ));
+  }
+
+  _launchURL() async {
+    const url =
+        'https://netid.cornell.edu/netidforgotpassword/forgotPasswordStart.htm';
+    if (await UrlLauncher.canLaunch(url)) {
+      await UrlLauncher.launch(url);
+    } else {
+      throw 'Could not launch $url';
+    }
+  }
+}

--- a/lib/Account_Name.dart
+++ b/lib/Account_Name.dart
@@ -1,0 +1,148 @@
+import 'package:carriage_rider/Account_Pronouns.dart';
+import 'package:flutter/material.dart';
+import 'package:carriage_rider/AuthProvider.dart';
+import 'RiderProvider.dart';
+import 'package:provider/provider.dart';
+import 'package:carriage_rider/app_config.dart';
+
+class AccountName extends StatefulWidget {
+  @override
+  _AccountNameState createState() => _AccountNameState();
+}
+
+class _AccountNameState extends State<AccountName> {
+  final _formKey = GlobalKey<FormState>();
+  FocusNode focusNode = FocusNode();
+
+  //TextEditingController firstNameCtrl = TextEditingController();
+  //TextEditingController lastNameCtrl = TextEditingController();
+
+  final titleStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w400,
+    fontSize: 25,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    RiderProvider riderProvider = Provider.of<RiderProvider>(context);
+    AuthProvider authProvider = Provider.of(context);
+    String _firstName = riderProvider.info.firstName;
+    String _lastName = riderProvider.info.lastName;
+    return Scaffold(
+        resizeToAvoidBottomInset: false,
+        backgroundColor: Colors.white,
+        body: Container(
+          margin: EdgeInsets.only(top: 50.0, left: 20.0, right: 20.0),
+          child: Column(
+            children: <Widget>[
+              SizedBox(height: 50.0),
+              Row(
+                children: <Widget>[
+                  Flexible(
+                    child:
+                        Text("How should we address you?", style: titleStyle),
+                  )
+                ],
+              ),
+              SizedBox(height: 40.0),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: <Widget>[
+                    TextFormField(
+                        initialValue: riderProvider.info.firstName,
+                        focusNode: focusNode,
+                        decoration: InputDecoration(
+                          labelText: 'First Name',
+                          labelStyle: TextStyle(color: Colors.black),
+                          enabledBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(color: Colors.black),
+                          ),
+                        ),
+                        textInputAction: TextInputAction.next,
+                        validator: (input) {
+                          if (input.isEmpty) {
+                            return 'Please enter your first name';
+                          }
+                          return null;
+                        },
+                        onSaved: (input) {
+                          setState(() {
+                            _firstName = input;
+                          });
+                        },
+                        style: TextStyle(color: Colors.black, fontSize: 15),
+                        onFieldSubmitted: (value) =>
+                            FocusScope.of(context).nextFocus()),
+                    SizedBox(height: 20.0),
+                    TextFormField(
+                        initialValue: riderProvider.info.lastName,
+                        decoration: InputDecoration(
+                          labelText: 'Last Name',
+                          labelStyle: TextStyle(color: Colors.black),
+                          enabledBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(color: Colors.black),
+                          ),
+                        ),
+                        textInputAction: TextInputAction.done,
+                        validator: (input) {
+                          if (input.isEmpty) {
+                            return 'Please enter your last name';
+                          }
+                          return null;
+                        },
+                        onSaved: (input) {
+                          setState(() {
+                            _lastName = input;
+                          });
+                        },
+                        style: TextStyle(color: Colors.black, fontSize: 15)),
+                    SizedBox(height: 10.0)
+                  ],
+                ),
+              ),
+              SizedBox(height: 10.0),
+              Row(children: <Widget>[
+                Flexible(
+                    child: Text(
+                        'By continuing, I accept the Terms of Services and Privacy Policies',
+                        style:
+                            TextStyle(fontSize: 10, color: Colors.grey[500])))
+              ]),
+              Expanded(
+                child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 20.0),
+                      child: ButtonTheme(
+                        minWidth: MediaQuery.of(context).size.width * 0.8,
+                        height: 45.0,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(3)),
+                        child: RaisedButton(
+                          onPressed: () {
+                            if (_formKey.currentState.validate()) {
+                              _formKey.currentState.save();
+                              riderProvider.setNames(AppConfig.of(context),
+                                  authProvider, _firstName, _lastName);
+                              Navigator.pop(context);
+                            }
+                            Navigator.push(
+                                context,
+                                new MaterialPageRoute(
+                                    builder: (context) => AccountPronouns()));
+                          },
+                          elevation: 3.0,
+                          color: Colors.black,
+                          textColor: Colors.white,
+                          child: Text('Next'),
+                        ),
+                      ),
+                    )),
+              )
+            ],
+          ),
+        ));
+  }
+}

--- a/lib/Account_Number.dart
+++ b/lib/Account_Number.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:carriage_rider/Home.dart';
+import 'package:carriage_rider/AuthProvider.dart';
+import 'RiderProvider.dart';
+import 'package:provider/provider.dart';
+import 'package:carriage_rider/app_config.dart';
+
+class AccountNumber extends StatefulWidget {
+  @override
+  _AccountNumberState createState() => _AccountNumberState();
+}
+
+class _AccountNumberState extends State<AccountNumber> {
+  final _formKey = GlobalKey<FormState>();
+  FocusNode focusNode = FocusNode();
+  TextEditingController phoneCtrl = TextEditingController();
+
+  Widget _buildPhoneNumberField() {
+    return TextFormField(
+      controller: phoneCtrl,
+      focusNode: focusNode,
+      decoration: InputDecoration(
+          labelText: 'Phone Number',
+          labelStyle: TextStyle(color: Colors.black)),
+      validator: (input) {
+        if (input.isEmpty) {
+          return 'Please enter your phone number';
+        }
+        return null;
+      },
+      style: TextStyle(color: Colors.black, fontSize: 15),
+    );
+  }
+
+  final titleStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w400,
+    fontSize: 25,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    RiderProvider riderProvider = Provider.of<RiderProvider>(context);
+    AuthProvider authProvider = Provider.of(context);
+    return Scaffold(
+        resizeToAvoidBottomInset: false,
+        backgroundColor: Colors.white,
+        body: Container(
+          margin: EdgeInsets.only(top: 50.0, left: 20.0, right: 20.0),
+          child: Column(
+            children: <Widget>[
+              SizedBox(height: 50.0),
+              Row(
+                children: <Widget>[
+                  Flexible(
+                    child: Text("And your phone number?", style: titleStyle),
+                  )
+                ],
+              ),
+              SizedBox(height: 40.0),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: <Widget>[
+                    _buildPhoneNumberField(),
+                    SizedBox(height: 10.0)
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 20.0),
+                      child: ButtonTheme(
+                        minWidth: MediaQuery.of(context).size.width * 0.8,
+                        height: 45.0,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(3)),
+                        child: RaisedButton(
+                          onPressed: () {
+                            if (_formKey.currentState.validate()) {
+                              _formKey.currentState.save();
+                              riderProvider.setPhone(AppConfig.of(context),
+                                  authProvider, phoneCtrl.text);
+                              Navigator.pop(context);
+                            }
+                            Navigator.push(
+                                context,
+                                new MaterialPageRoute(
+                                    builder: (context) => Home()));
+                          },
+                          elevation: 3.0,
+                          color: Colors.black,
+                          textColor: Colors.white,
+                          child: Text('Done'),
+                        ),
+                      ),
+                    )),
+              )
+            ],
+          ),
+        ));
+  }
+}

--- a/lib/Account_Pronouns.dart
+++ b/lib/Account_Pronouns.dart
@@ -1,0 +1,150 @@
+import 'package:carriage_rider/Account_Number.dart';
+import 'package:flutter/material.dart';
+import 'package:carriage_rider/AuthProvider.dart';
+import 'RiderProvider.dart';
+import 'package:provider/provider.dart';
+import 'package:carriage_rider/app_config.dart';
+
+class AccountPronouns extends StatefulWidget {
+  @override
+  _AccountPronounsState createState() => _AccountPronounsState();
+}
+
+class _AccountPronounsState extends State<AccountPronouns> {
+  int selectedRadio = 0;
+
+  String pronouns = "";
+
+  setPronouns(String pronoun) {
+    pronouns = pronoun;
+  }
+
+  setSelectedRadio(int val) {
+    setState(() {
+      selectedRadio = val;
+    });
+  }
+
+  final cancelStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w100,
+    fontSize: 15,
+  );
+
+  final titleStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w400,
+    fontSize: 25,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    RiderProvider riderProvider = Provider.of<RiderProvider>(context);
+    AuthProvider authProvider = Provider.of(context);
+    return Scaffold(
+      body: Container(
+        margin: EdgeInsets.only(top: 50.0, left: 20.0, right: 20.0),
+        child: Column(
+          children: <Widget>[
+            SizedBox(height: 60.0),
+            Row(
+              children: <Widget>[
+                Flexible(child: Text("Share your pronouns", style: titleStyle))
+              ],
+            ),
+            SizedBox(height: 15.0),
+            Row(children: <Widget>[
+              Flexible(
+                  child: Text(
+                      "Help us get better at addressing you by selecting your pronouns",
+                      style: TextStyle(fontSize: 15, color: Colors.grey)))
+            ]),
+            SizedBox(height: 40),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                RadioListTile(
+                  title: Text("They/Them/Theirs"),
+                  value: 1,
+                  groupValue: selectedRadio,
+                  activeColor: Colors.black,
+                  onChanged: (val) {
+                    setSelectedRadio(val);
+                    setPronouns("They/Them/Theirs");
+                  },
+                ),
+                RadioListTile(
+                  title: Text("She/Her/Hers"),
+                  value: 2,
+                  groupValue: selectedRadio,
+                  activeColor: Colors.black,
+                  onChanged: (val) {
+                    setSelectedRadio(val);
+                    setPronouns("She/Her/Hers");
+                  },
+                ),
+                RadioListTile(
+                  title: Text("He/Him/His"),
+                  value: 3,
+                  groupValue: selectedRadio,
+                  activeColor: Colors.black,
+                  onChanged: (val) {
+                    setSelectedRadio(val);
+                    setPronouns("He/Him/His");
+                  },
+                ),
+                RadioListTile(
+                  title: Text("Others"),
+                  value: 4,
+                  groupValue: selectedRadio,
+                  activeColor: Colors.black,
+                  onChanged: (val) {
+                    setSelectedRadio(val);
+                    setPronouns("Others");
+                  },
+                ),
+                RadioListTile(
+                  title: Text("Prefer not to say"),
+                  value: 5,
+                  groupValue: selectedRadio,
+                  activeColor: Colors.black,
+                  onChanged: (val) {
+                    setSelectedRadio(val);
+                    setPronouns("");
+                  },
+                ),
+              ],
+            ),
+            Expanded(
+              child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 20.0),
+                    child: ButtonTheme(
+                      minWidth: MediaQuery.of(context).size.width * 0.8,
+                      height: 45.0,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(3)),
+                      child: RaisedButton(
+                        onPressed: () {
+                          riderProvider.setPronouns(
+                              AppConfig.of(context), authProvider, pronouns);
+                          Navigator.push(
+                              context,
+                              new MaterialPageRoute(
+                                  builder: (context) => AccountNumber()));
+                        },
+                        elevation: 3.0,
+                        color: Colors.black,
+                        textColor: Colors.white,
+                        child: Text('Next'),
+                      ),
+                    ),
+                  )),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Current.dart
+++ b/lib/Current.dart
@@ -62,7 +62,7 @@ class _CurrentState extends State<Current> {
                                 left: SizeConfig.safeBlockHorizontal * 7,
                               ),
                               child:
-                                  headerText("Current Ride", Colors.white, 35)),
+                              headerText("Current Ride", Colors.white, 35)),
                         ],
                       ),
                     ],
@@ -149,9 +149,9 @@ class _CurrentState extends State<Current> {
           children: <Widget>[
             infoDivider(),
             Container(
-              padding: EdgeInsets.only(
-                top: SizeConfig.safeBlockHorizontal * 4,
-              )
+                padding: EdgeInsets.only(
+                  top: SizeConfig.safeBlockHorizontal * 4,
+                )
             ),
             Container(
               margin: EdgeInsets.only(left: 15),
@@ -278,7 +278,7 @@ class _CurrentState extends State<Current> {
       children: <Widget>[
         Text('$title\n $subTile',
             style:
-                TextStyle(fontFamily: "regular", fontSize: 19, color: color)),
+            TextStyle(fontFamily: "regular", fontSize: 19, color: color)),
       ],
     );
   }

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -1,10 +1,10 @@
+import 'package:carriage_rider/Request_Ride_Loc.dart';
 import 'package:carriage_rider/AuthProvider.dart';
 import 'package:carriage_rider/Confirmed_Ride.dart';
 import 'package:carriage_rider/Current.dart';
 import 'package:carriage_rider/History.dart';
 import 'package:carriage_rider/Notifications.dart';
 import 'package:carriage_rider/Profile.dart';
-import 'package:carriage_rider/Request_Ride_Loc.dart';
 import 'package:carriage_rider/Upcoming.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/Ride_History.dart';
@@ -39,9 +39,7 @@ class Home extends StatelessWidget {
       return Text(
         text,
         textAlign: TextAlign.left,
-        style: TextStyle(
-            color: color,
-            fontFamily: 'SFPro'),
+        style: TextStyle(color: color, fontFamily: 'SFPro'),
       );
     }
 
@@ -63,7 +61,7 @@ class Home extends StatelessWidget {
               ),
               ListTile(
                 leading: Icon(Icons.settings, color: Colors.black),
-                title:  sideBarText("Settings", Colors.black),
+                title: sideBarText("Settings", Colors.black),
                 onTap: () {
                   Navigator.push(context,
                       new MaterialPageRoute(builder: (context) => Settings()));
@@ -122,8 +120,10 @@ class Home extends StatelessWidget {
                 leading: Icon(Icons.check, color: Colors.black),
                 title: sideBarText("Confirmed Ride", Colors.black),
                 onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => ConfirmedRide()));
+                  Navigator.push(
+                      context,
+                      new MaterialPageRoute(
+                          builder: (context) => ConfirmedRide()));
                 },
               )
             ],
@@ -200,11 +200,9 @@ class Home extends StatelessWidget {
                             textColor: Colors.white,
                             icon: Icon(Icons.add),
                             label: Text('Request Ride',
-                                style: TextStyle(
-                                    fontSize: 18
-                                )),
+                                style: TextStyle(fontSize: 18)),
                           ),
-                        ))
+                        )),
                   ],
                 ),
               ),

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:ui';
 import 'package:carriage_rider/AuthProvider.dart';
 import 'package:carriage_rider/Upcoming.dart';
@@ -7,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'dart:core';
 import 'package:provider/provider.dart';
 import 'RiderProvider.dart';
+import 'package:image_picker/image_picker.dart';
 
 class Profile extends StatefulWidget {
   @override
@@ -14,9 +16,23 @@ class Profile extends StatefulWidget {
 }
 
 class _ProfileState extends State<Profile> {
+  File _image;
+
   @override
   void initState() {
     super.initState();
+  }
+
+  Future _getImage() async {
+    final pickedFile = await ImagePicker.pickImage(source: ImageSource.gallery);
+
+    setState(() {
+      if (pickedFile != null) {
+        _image = File(pickedFile.path);
+      } else {
+        print('No image selected.');
+      }
+    });
   }
 
   @override
@@ -86,8 +102,10 @@ class _ProfileState extends State<Profile> {
                                     bottom: _picDiameter * 0.05),
                                 child: CircleAvatar(
                                   backgroundImage: NetworkImage(
-                                    authProvider
-                                        .googleSignIn.currentUser.photoUrl,
+                                    _image == null
+                                        ? authProvider
+                                            .googleSignIn.currentUser.photoUrl
+                                        : Image.file(_image),
                                   ),
                                   radius: _picRadius,
                                 )),
@@ -100,7 +118,9 @@ class _ProfileState extends State<Profile> {
                                       backgroundColor: Colors.black,
                                       child: Icon(Icons.add,
                                           size: _picBtnDiameter),
-                                      onPressed: () {},
+                                      onPressed: () {
+                                        _getImage();
+                                      },
                                     ),
                                   ),
                                 ),
@@ -128,7 +148,8 @@ class _ProfileState extends State<Profile> {
                                           context,
                                           MaterialPageRoute(
                                               builder: (context) =>
-                                                  EditProfile(riderProvider.info)));
+                                                  EditProfileName(
+                                                      riderProvider.info)));
                                     },
                                   )
                                 ]),
@@ -242,17 +263,30 @@ class _ProfileInfoState extends State<ProfileInfo> {
   }
 }
 
-class EditProfile extends StatefulWidget {
-  EditProfile(this.rider);
+class EditProfileName extends StatefulWidget {
+  EditProfileName(this.rider);
 
   final Rider rider;
 
   @override
-  _EditProfileState createState() => _EditProfileState();
+  _EditProfileNameState createState() => _EditProfileNameState();
 }
 
-class _EditProfileState extends State<EditProfile> {
+class _EditProfileNameState extends State<EditProfileName> {
   final _formKey = GlobalKey<FormState>();
+  FocusNode focusNode = FocusNode();
+
+  final cancelStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w100,
+    fontSize: 15,
+  );
+
+  final titleStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w400,
+    fontSize: 25,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -260,99 +294,132 @@ class _EditProfileState extends State<EditProfile> {
     AuthProvider authProvider = Provider.of(context);
     String _firstName = widget.rider.firstName;
     String _lastName = widget.rider.lastName;
-    String _phoneNumber = widget.rider.phoneNumber;
-    // TODO: implement build
     return Scaffold(
-        body: Padding(
-      padding: EdgeInsets.only(left: 24.0, top: 10.0, bottom: 8.0),
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text('Edit Profile', style: Theme.of(context).textTheme.headline5),
-        SizedBox(height: 20),
-        Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('First Name',
-                    style:
-                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                TextFormField(
-                  decoration: InputDecoration(icon: Icon(Icons.person)),
-                  initialValue: _firstName,
-                  validator: (input) {
-                    if (input.isEmpty) {
-                      return 'Please enter your first name.';
-                    }
-                    return null;
-                  },
-                  onSaved: (input) {
-                    setState(() {
-                      _firstName = input;
-                    });
-                  },
+        resizeToAvoidBottomInset: false,
+        backgroundColor: Colors.white,
+        body: Container(
+          margin: EdgeInsets.only(top: 50.0, left: 20.0, right: 20.0),
+          child: Column(
+            children: <Widget>[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: <Widget>[
+                  Container(
+                    child: InkWell(
+                      child: Text("Cancel", style: cancelStyle),
+                      onTap: () {
+                        Navigator.pop(
+                            context,
+                            new MaterialPageRoute(
+                                builder: (context) => Profile()));
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 50.0),
+              Row(
+                children: <Widget>[
+                  Flexible(
+                    child:
+                        Text("How should we address you?", style: titleStyle),
+                  )
+                ],
+              ),
+              SizedBox(height: 40.0),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: <Widget>[
+                    TextFormField(
+                        initialValue: riderProvider.info.firstName,
+                        focusNode: focusNode,
+                        decoration: InputDecoration(
+                          labelText: 'First Name',
+                          labelStyle: TextStyle(color: Colors.black),
+                          enabledBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(color: Colors.black),
+                          ),
+                        ),
+                        textInputAction: TextInputAction.next,
+                        validator: (input) {
+                          if (input.isEmpty) {
+                            return 'Please enter your first name';
+                          }
+                          return null;
+                        },
+                        onSaved: (input) {
+                          setState(() {
+                            _firstName = input;
+                          });
+                        },
+                        style: TextStyle(color: Colors.black, fontSize: 15),
+                        onFieldSubmitted: (value) =>
+                            FocusScope.of(context).nextFocus()),
+                    SizedBox(height: 20.0),
+                    TextFormField(
+                        initialValue: riderProvider.info.lastName,
+                        decoration: InputDecoration(
+                          labelText: 'Last Name',
+                          labelStyle: TextStyle(color: Colors.black),
+                          enabledBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(color: Colors.black),
+                          ),
+                        ),
+                        textInputAction: TextInputAction.done,
+                        validator: (input) {
+                          if (input.isEmpty) {
+                            return 'Please enter your last name';
+                          }
+                          return null;
+                        },
+                        onSaved: (input) {
+                          setState(() {
+                            _lastName = input;
+                          });
+                        },
+                        style: TextStyle(color: Colors.black, fontSize: 15)),
+                    SizedBox(height: 10.0)
+                  ],
                 ),
-                SizedBox(height: 20),
-                Text('Last Name',
-                    style:
-                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                TextFormField(
-                  decoration: InputDecoration(icon: Icon(Icons.person)),
-                  initialValue: _lastName,
-                  validator: (input) {
-                    if (input.isEmpty) {
-                      return 'Please enter your last name.';
-                    }
-                    return null;
-                  },
-                  onSaved: (input) {
-                    setState(() {
-                      _lastName = input;
-                    });
-                  },
-                ),
-                SizedBox(height: 20),
-                Text('Phone Number',
-                    style:
-                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                TextFormField(
-                  decoration: InputDecoration(icon: Icon(Icons.phone)),
-                  initialValue: _phoneNumber,
-                  keyboardType: TextInputType.number,
-                  validator: (input) {
-                    if (input.isEmpty) {
-                      return 'Please enter your phone number.';
-                    }
-                    return null;
-                  },
-                  onSaved: (input) {
-                    setState(() {
-                      _phoneNumber = input;
-                    });
-                  },
-                ),
-              ],
-            )),
-        SizedBox(height: 15),
-        Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-          RaisedButton(
-            child: Text("Save"),
-            onPressed: () {
-              if (_formKey.currentState.validate()) {
-                _formKey.currentState.save();
-                riderProvider.updateRider(AppConfig.of(context),
-                    authProvider, _firstName, _lastName, _phoneNumber);
-                Navigator.pop(context);
-              }
-            },
+              ),
+              SizedBox(height: 10.0),
+              Row(children: <Widget>[
+                Flexible(
+                    child: Text(
+                        'By continuing, I accept the Terms of Services and Privacy Policies',
+                        style:
+                            TextStyle(fontSize: 10, color: Colors.grey[500])))
+              ]),
+              Expanded(
+                child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 20.0),
+                      child: ButtonTheme(
+                        minWidth: MediaQuery.of(context).size.width * 0.8,
+                        height: 45.0,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(3)),
+                        child: RaisedButton(
+                          onPressed: () {
+                            if (_formKey.currentState.validate()) {
+                              _formKey.currentState.save();
+                              riderProvider.setNames(AppConfig.of(context),
+                                  authProvider, _firstName, _lastName);
+                              Navigator.pop(context);
+                            }
+                          },
+                          elevation: 3.0,
+                          color: Colors.black,
+                          textColor: Colors.white,
+                          child: Text('Done'),
+                        ),
+                      ),
+                    )),
+              )
+            ],
           ),
-          SizedBox(width: 30),
-          RaisedButton(
-              child: Text("Cancel"),
-              onPressed: () {
-                Navigator.pop(context);
-              })
-        ])
-      ]),
-    ));
+        ));
   }
 }

--- a/lib/Ride_Confirmation.dart
+++ b/lib/Ride_Confirmation.dart
@@ -6,7 +6,6 @@ class RideConfirmation extends StatefulWidget {
 }
 
 class _RideConfirmationState extends State<RideConfirmation> {
-
   final requestStyle = TextStyle(
     color: Colors.black,
     fontWeight: FontWeight.w700,
@@ -24,10 +23,8 @@ class _RideConfirmationState extends State<RideConfirmation> {
     return Scaffold(
       body: Column(
         children: <Widget>[
-          SizedBox(height: MediaQuery.of(context).size.height*0.2),
-          Image(
-            image: AssetImage('assets/images/RequestInProgress.png')
-          ),
+          SizedBox(height: MediaQuery.of(context).size.height * 0.2),
+          Image(image: AssetImage('assets/images/RequestInProgress.png')),
           SizedBox(height: 10),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -39,13 +36,15 @@ class _RideConfirmationState extends State<RideConfirmation> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Text('You\'ll be notified via in-app notification', style: descriptionStyle)
+              Text('You\'ll be notified via in-app notification',
+                  style: descriptionStyle)
             ],
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Text('and email when your ride is confirmed', style: descriptionStyle)
+              Text('and email when your ride is confirmed',
+                  style: descriptionStyle)
             ],
           ),
           Expanded(
@@ -56,9 +55,10 @@ class _RideConfirmationState extends State<RideConfirmation> {
                   child: ButtonTheme(
                     minWidth: MediaQuery.of(context).size.width * 0.8,
                     height: 45.0,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(3)),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(3)),
                     child: RaisedButton(
-                      onPressed: (){
+                      onPressed: () {
                         Navigator.popUntil(context, ModalRoute.withName('/'));
                       },
                       elevation: 3.0,
@@ -67,8 +67,7 @@ class _RideConfirmationState extends State<RideConfirmation> {
                       child: Text('Done'),
                     ),
                   ),
-                )
-            ),
+                )),
           )
         ],
       ),

--- a/lib/RiderProvider.dart
+++ b/lib/RiderProvider.dart
@@ -14,9 +14,6 @@ class Rider {
   final String lastName;
   final String pronouns;
   final Map accessibilityNeeds;
-  final bool hasWheelchair;
-  final bool hasCrutches;
-  final bool needsAssistant;
   final String description;
   final String picture;
   final String joinDate;
@@ -31,9 +28,6 @@ class Rider {
     this.lastName,
     this.pronouns,
     this.accessibilityNeeds,
-    this.hasWheelchair,
-    this.hasCrutches,
-    this.needsAssistant,
     this.description,
     this.picture,
     this.joinDate,
@@ -48,9 +42,6 @@ class Rider {
         lastName: json['lastName'],
         pronouns: json['pronouns'],
         accessibilityNeeds: json['accessibilityNeeds'],
-        hasWheelchair: json['hasWheelchair'],
-        hasCrutches: json['hasCrutches'],
-        needsAssistant: json['needsAssistant'],
         description: json['description'],
         picture: json['picture'],
         joinDate: json['joinDate']);
@@ -64,8 +55,6 @@ class Rider {
         'lastName': lastName,
         'pronouns': picture,
         'accessibilityNeeds': accessibilityNeeds,
-        'hasWheelchair': hasWheelchair,
-        'needsAssistant': needsAssistant,
         'description': description,
         'picture': picture,
         'joinDate': joinDate,
@@ -93,6 +82,16 @@ class RiderProvider with ChangeNotifier {
   void _setInfo(Rider info) {
     this.info = info;
     notifyListeners();
+  }
+
+  void check(AuthProvider authProvider, response) {
+    if (response.statusCode == 200) {
+      Map<String, dynamic> json = jsonDecode(response.body);
+      _setInfo(
+          Rider.fromJson(json, authProvider.googleSignIn.currentUser.photoUrl));
+    } else {
+      throw Exception('Failed to update driver.');
+    }
   }
 
   Future<void> fetchRider(AppConfig config, AuthProvider authProvider) async {
@@ -123,12 +122,63 @@ class RiderProvider with ChangeNotifier {
         'phoneNumber': phoneNumber,
       }),
     );
-    if (response.statusCode == 200) {
-      Map<String,dynamic> json = jsonDecode(response.body);
-      _setInfo(Rider.fromJson(
-          json, authProvider.googleSignIn.currentUser.photoUrl));
-    } else {
-      throw Exception('Failed to update driver.');
-    }
+    check(authProvider, response);
+  }
+
+  Future<void> setNames(AppConfig config, AuthProvider authProvider,
+      String firstName, String lastName) async {
+    final response = await http.put(
+      "${config.baseUrl}/riders/${authProvider.id}",
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(<String, String>{
+        'firstName': firstName,
+        'lastName': lastName,
+      }),
+    );
+    check(authProvider, response);
+  }
+
+  Future<void> setEmail(
+      AppConfig config, AuthProvider authProvider, String email) async {
+    final response = await http.put(
+      "${config.baseUrl}/riders/${authProvider.id}",
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(<String, String>{
+        'email': email,
+      }),
+    );
+    check(authProvider, response);
+  }
+
+  Future<void> setPronouns(
+      AppConfig config, AuthProvider authProvider, String pronouns) async {
+    final response = await http.put(
+      "${config.baseUrl}/riders/${authProvider.id}",
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(<String, String>{
+        'pronouns': pronouns,
+      }),
+    );
+    check(authProvider, response);
+  }
+
+  Future<void> setPhone(
+      AppConfig config, AuthProvider authProvider, String phoneNumber) async {
+    final response = await http.put(
+      "${config.baseUrl}/riders/${authProvider.id}",
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(<String, String>{
+        'phoneNumber': phoneNumber,
+      }),
+    );
+    check(authProvider, response);
   }
 }

--- a/lib/Settings.dart
+++ b/lib/Settings.dart
@@ -8,7 +8,6 @@ import 'dart:core';
 import 'RiderProvider.dart';
 
 class Settings extends StatefulWidget {
-
   @override
   _SettingsState createState() => _SettingsState();
 }
@@ -248,7 +247,7 @@ class _PrivacyLegalInfoState extends State<PrivacyLegalInfo> {
                         alignment: Alignment.topLeft,
                         child: Text(heading,
                             style: TextStyle(
-                                fontSize: 20, fontWeight: FontWeight.bold)),
+                                fontSize: 18, fontWeight: FontWeight.bold)),
                       ),
                     ),
                     Expanded(
@@ -268,7 +267,7 @@ class _PrivacyLegalInfoState extends State<PrivacyLegalInfo> {
                 child: Text(
                   text,
                   style: TextStyle(
-                    fontSize: 17,
+                    fontSize: 16,
                     color: Theme.of(context).accentColor,
                   ),
                 ),
@@ -280,8 +279,9 @@ class _PrivacyLegalInfoState extends State<PrivacyLegalInfo> {
 
   @override
   Widget build(BuildContext context) {
-    List<String> headings = ["Privacy", "Legal"];
+    List<String> headings = ["Email Preferences", "Privacy", "Legal"];
     final List<String> subText = [
+      "Set what email you want to receive",
       "Choose what data you share with us",
       "Terms of service \& Privacy Policy"
     ];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.4"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -149,6 +156,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.12"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.6+5"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   intl: ^0.16.1
   provider: ^4.0.5+1
   url_launcher: ^5.0.2
+  image_picker: ^0.6.6+5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request completes the implementation of account setup for the Rider app. The account setup pages allows the rider to set their name, phone number, and preferred pronouns when users first login to the app. The information users input for account setup is updated for each rider in the backend. This pull request also allows the user to edit a rider's first, last name, and profile picture on the Profile page. 

### Test Plan <!-- Required -->

I tested the account setup pages and the saving of rider information with an emulator.

<img width="292" alt="Screen Shot 2020-10-10 at 4 07 55 AM" src="https://user-images.githubusercontent.com/17262023/95671922-5080f680-0b6a-11eb-8a5a-8bb01e533474.png">
<img width="316" alt="Screen Shot 2020-10-10 at 4 04 01 AM" src="https://user-images.githubusercontent.com/17262023/95671938-773f2d00-0b6a-11eb-89bf-b029bd7810f8.png">
<img width="310" alt="Screen Shot 2020-10-10 at 4 08 14 AM" src="https://user-images.githubusercontent.com/17262023/95671940-7dcda480-0b6a-11eb-8cd9-63e08b8f7965.png">
<img width="307" alt="Screen Shot 2020-10-10 at 4 08 19 AM" src="https://user-images.githubusercontent.com/17262023/95671942-81612b80-0b6a-11eb-96af-338f4d830972.png">

### Notes <!-- Optional -->

- Fix navigation with login and home and account set up
