### PR TITLE
Fix Invalid Argument(s) Error in Profile

### DIFF
--- a/lib/RiderProvider.dart
+++ b/lib/RiderProvider.dart
@@ -45,7 +45,7 @@ class Rider {
         ),
         json['description'],
         json['picture'],
-        json['joindate']);
+        json['joinDate']);
   }
 
   Map<String, dynamic> toJson() => {


### PR DESCRIPTION
### Summary <!-- Required -->
Fixed invalid argument(s) error that was causing Profile to not load. Had to do with accessing the joinDate using the wrong key in the map.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->
See that the Profile page can load instead of showing us a red screen with an error message
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
