### PR TITLE
Refactored Upcoming Ride Cards

### DIFF
--- a/lib/Current_Ride.dart
+++ b/lib/Current_Ride.dart
@@ -21,7 +21,6 @@ class CurrentRide extends StatelessWidget {
     );
 
     return Container(
-      margin: EdgeInsets.only(left: 17.0, right: 17.0),
       decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(3.0), boxShadow: [
         BoxShadow(color: Colors.grey[500], blurRadius: 3.0)
@@ -50,7 +49,7 @@ class CurrentRide extends StatelessWidget {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                        Text('Your driver will arrive in 2 mintues',
+                        Text('Your driver will arrive in 2 minutes',
                           style: TextStyle(color: Colors.white),
                         ),
                       ],

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -24,16 +24,22 @@ class Home extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    //TODO: change to get name from rider provider
     AuthProvider authProvider = Provider.of(context);
     final String headerName = "Hi " +
         authProvider.googleSignIn.currentUser.displayName.split(" ")[0] +
-        "!";
+        "! ☀";
+
     final subHeadingStyle = TextStyle(
         color: Colors.grey[700],
         fontWeight: FontWeight.w700,
-        letterSpacing: 0.3,
-        fontSize: 20,
-        height: 2);
+        fontSize: 20
+    );
+
+    final seeMoreStyle = TextStyle(
+        fontSize: 14,
+        color: Color(0xFF181818)
+    );
 
     Widget sideBarText(String text, Color color) {
       return Text(
@@ -44,170 +50,219 @@ class Home extends StatelessWidget {
     }
 
     return Scaffold(
-        endDrawer: Drawer(
-          child: ListView(
-            padding: EdgeInsets.all(5.0),
-            children: <Widget>[
-              ListTile(
-                leading: Icon(Icons.person, color: Colors.black),
-                title: sideBarText("Profile", Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Profile()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.settings, color: Colors.black),
-                title: sideBarText("Settings", Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Settings()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.notifications, color: Colors.black),
-                title: sideBarText("Notifications", Colors.black),
-                onTap: () {
-                  Navigator.push(
-                      context,
-                      new MaterialPageRoute(
-                          builder: (context) => Notifications()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.directions_car, color: Colors.black),
-                title: sideBarText("Current Ride", Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Current()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.trending_up, color: Colors.black),
-                title: sideBarText("Upcoming Ride", Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Upcoming()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.history, color: Colors.black),
-                title: sideBarText("Ride History", Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => History()));
-                },
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              ListTile(
-                leading: Icon(Icons.check, color: Colors.black),
-                title: sideBarText("Confirmed Ride", Colors.black),
-                onTap: () {
-                  Navigator.push(
-                      context,
-                      new MaterialPageRoute(
-                          builder: (context) => ConfirmedRide()));
-                },
-              )
-            ],
-          ),
-        ),
-        appBar: AppBar(
-          title: Text(
-            headerName,
-            style: TextStyle(
-                color: Colors.black, fontSize: 30, fontFamily: 'SFPro'),
-          ),
-          backgroundColor: Colors.white,
-          iconTheme: IconThemeData(color: Colors.black),
-        ),
-        body: Stack(
-          children: <Widget>[
-            ListView(
-              scrollDirection: Axis.vertical,
+        endDrawer: SafeArea(
+          child: Drawer(
+            child: ListView(
+              padding: EdgeInsets.all(5.0),
               children: <Widget>[
-                Container(
-                  margin: EdgeInsets.only(top: 10.0, left: 17.0, bottom: 15.0),
-                  child: Text(
-                    'Next Ride',
-                    style: subHeadingStyle,
-                  ),
+                ListTile(
+                  leading: Icon(Icons.person, color: Colors.black),
+                  title: sideBarText("Profile", Colors.black),
+                  onTap: () {
+                    Navigator.push(context,
+                        new MaterialPageRoute(builder: (context) => Profile()));
+                  },
                 ),
-                CurrentRide(),
-                Container(
-                  margin: EdgeInsets.only(top: 10.0, left: 17.0, bottom: 15.0),
-                  child: Text(
-                    'Upcoming Rides',
-                    style: subHeadingStyle,
-                  ),
+                Divider(
+                  color: Colors.grey[500],
                 ),
-                UpcomingRide(),
-                Container(
-                  margin: EdgeInsets.only(top: 10.0, left: 17.0, bottom: 15.0),
-                  child: Text(
-                    'Ride History',
-                    style: subHeadingStyle,
-                  ),
+                ListTile(
+                  leading: Icon(Icons.settings, color: Colors.black),
+                  title: sideBarText("Settings", Colors.black),
+                  onTap: () {
+                    Navigator.push(context,
+                        new MaterialPageRoute(builder: (context) => Settings()));
+                  },
                 ),
-                RideHistory(),
-                SizedBox(
-                  width: MediaQuery.of(context).size.width,
-                  height: MediaQuery.of(context).size.height / 8,
+                Divider(
+                  color: Colors.grey[500],
+                ),
+                ListTile(
+                  leading: Icon(Icons.notifications, color: Colors.black),
+                  title: sideBarText("Notifications", Colors.black),
+                  onTap: () {
+                    Navigator.push(
+                        context,
+                        new MaterialPageRoute(
+                            builder: (context) => Notifications()));
+                  },
+                ),
+                Divider(
+                  color: Colors.grey[500],
+                ),
+                ListTile(
+                  leading: Icon(Icons.directions_car, color: Colors.black),
+                  title: sideBarText("Current Ride", Colors.black),
+                  onTap: () {
+                    Navigator.push(context,
+                        new MaterialPageRoute(builder: (context) => Current()));
+                  },
+                ),
+                Divider(
+                  color: Colors.grey[500],
+                ),
+                ListTile(
+                  leading: Icon(Icons.trending_up, color: Colors.black),
+                  title: sideBarText("Upcoming Ride", Colors.black),
+                  onTap: () {
+                    Navigator.push(context,
+                        new MaterialPageRoute(builder: (context) => Upcoming()));
+                  },
+                ),
+                Divider(
+                  color: Colors.grey[500],
+                ),
+                ListTile(
+                  leading: Icon(Icons.history, color: Colors.black),
+                  title: sideBarText("Ride History", Colors.black),
+                  onTap: () {
+                    Navigator.push(context,
+                        new MaterialPageRoute(builder: (context) => History()));
+                  },
+                ),
+                Divider(
+                  color: Colors.grey[500],
+                ),
+                ListTile(
+                  leading: Icon(Icons.check, color: Colors.black),
+                  title: sideBarText("Confirmed Ride", Colors.black),
+                  onTap: () {
+                    Navigator.push(
+                        context,
+                        new MaterialPageRoute(
+                            builder: (context) => ConfirmedRide()));
+                  },
                 )
               ],
             ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                width: MediaQuery.of(context).size.width,
-                height: MediaQuery.of(context).size.height / 8,
-                color: Colors.white,
-                child: Stack(
-                  children: <Widget>[
-                    Align(
-                        alignment: Alignment.center,
-                        child: ButtonTheme(
-                          minWidth: MediaQuery.of(context).size.width * 0.8,
-                          height: 45.0,
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(3)),
-                          child: RaisedButton.icon(
-                            onPressed: () {
-                              Navigator.push(
-                                  context,
-                                  new MaterialPageRoute(
-                                      builder: (context) => RequestRideLoc()));
-                            },
-                            elevation: 3.0,
-                            color: Colors.black,
-                            textColor: Colors.white,
-                            icon: Icon(Icons.add),
-                            label: Text('Request Ride',
-                                style: TextStyle(fontSize: 18)),
+          ),
+        ),
+        body: SafeArea(
+          child: Stack(
+            children: <Widget>[
+              CustomScrollView(
+                  slivers: [
+                    SliverAppBar(
+                      elevation: 11,
+                      pinned: true,
+                      expandedHeight: 100,
+                      collapsedHeight: 100,
+                      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+                      flexibleSpace: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          Row(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(left: 16, right: 16, bottom: 23),
+                                child: Text(
+                                  headerName,
+                                  style: TextStyle(
+                                      color: Colors.black, fontSize: 30, fontFamily: 'SFPro', fontWeight: FontWeight.w700),
+                                ),
+                              ),
+                              Spacer(),
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 23),
+                                child: Builder(
+                                    builder: (BuildContext context) {
+                                      return IconButton(
+                                          icon: Icon(Icons.menu, color: Colors.black),
+                                          onPressed: () => Scaffold.of(context).openEndDrawer()
+                                      );
+                                    }
+                                ),
+                              )
+                            ],
                           ),
-                        )),
-                  ],
+                        ],
+                      ),
+                    ),
+                    SliverPadding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      sliver: SliverList(
+                          delegate: SliverChildListDelegate(
+                            [
+                              Text(
+                                'Current Ride',
+                                style: subHeadingStyle,
+                              ),
+                              SizedBox(height: 12),
+                              CurrentRide(),
+                              SizedBox(height: 35),
+                              Row(
+                                  children: [
+                                    Text(
+                                      'Upcoming Rides',
+                                      style: subHeadingStyle,
+                                    ),
+                                    Spacer(),
+                                    Text('See More', style: seeMoreStyle),
+                                    Icon(Icons.arrow_forward, size: 16)
+                                  ]
+                              ),
+                              SizedBox(height: 12),
+                              UpcomingRides(),
+                              SizedBox(height: 35),
+                              Row(
+                                  children: [
+                                    Text(
+                                      'Ride History',
+                                      style: subHeadingStyle,
+                                    ),
+                                    Spacer(),
+                                    Text('See More', style: seeMoreStyle),
+                                    Icon(Icons.arrow_forward, size: 16)
+                                  ]
+                              ),
+                              RideHistory(),
+                              SizedBox(
+                                width: MediaQuery.of(context).size.width,
+                                height: MediaQuery.of(context).size.height / 8,
+                              )
+                            ],
+                          )
+                      ),
+                    ),
+                  ]
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  width: MediaQuery.of(context).size.width,
+                  height: MediaQuery.of(context).size.height / 8,
+                  color: Colors.white,
+                  child: Stack(
+                    children: <Widget>[
+                      Align(
+                          alignment: Alignment.center,
+                          child: ButtonTheme(
+                            minWidth: MediaQuery.of(context).size.width * 0.8,
+                            height: 45.0,
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(3)),
+                            child: RaisedButton.icon(
+                              onPressed: () {
+                                Navigator.push(
+                                    context,
+                                    new MaterialPageRoute(
+                                        builder: (context) => RequestRideLoc()));
+                              },
+                              elevation: 3.0,
+                              color: Colors.black,
+                              textColor: Colors.white,
+                              icon: Icon(Icons.add),
+                              label: Text('Request Ride',
+                                  style: TextStyle(fontSize: 18)),
+                            ),
+                          )),
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ));
   }
 }

--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -1,5 +1,10 @@
 import 'dart:core';
 import 'package:carriage_rider/RiderProvider.dart';
+import 'package:flutter/material.dart';
+import 'package:humanize/humanize.dart';
+import 'package:intl/intl.dart';
+
+import 'TextThemes.dart';
 
 class Ride {
   final String id;
@@ -28,6 +33,25 @@ class Ride {
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
       rider: Rider.fromJson(json['rider']),
+    );
+  }
+
+  Widget buildStartTime() {
+    return RichText(
+      text: TextSpan(
+          text: DateFormat('MMM').format(startTime).toUpperCase() + ' ',
+          style: TextThemes.monthStyle,
+          children: [
+            TextSpan(
+                text: ordinal(int.parse(DateFormat('d')
+                    .format(startTime))) +
+                    ' ',
+                style: TextThemes.dayStyle),
+            TextSpan(
+                text: DateFormat('jm').format(startTime),
+                style: TextThemes.timeStyle)
+          ]
+      ),
     );
   }
 }

--- a/lib/Ride_History.dart
+++ b/lib/Ride_History.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:carriage_rider/RidesProvider.dart';
 import 'package:carriage_rider/AuthProvider.dart';
 import 'package:provider/provider.dart';
-import 'package:carriage_rider/RideProvider.dart';
+import 'package:carriage_rider/Ride.dart';
 import 'package:carriage_rider/app_config.dart';
 import 'package:intl/intl.dart';
 import 'package:humanize/humanize.dart' as humanize;

--- a/lib/RidesProvider.dart
+++ b/lib/RidesProvider.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'app_config.dart';
 import 'package:carriage_rider/app_config.dart';
 import 'package:carriage_rider/AuthProvider.dart';
-import 'package:carriage_rider/RideProvider.dart';
+import 'package:carriage_rider/Ride.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 

--- a/lib/TextThemes.dart
+++ b/lib/TextThemes.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class TextThemes {
+
+  static final directionStyle = TextStyle(
+    color: Colors.grey[500],
+    fontWeight: FontWeight.w500,
+    fontSize: 12,
+  );
+
+  static final rideInfoStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w400,
+    fontSize: 17,
+  );
+
+  static final monthStyle = TextStyle(
+    color: Colors.black,
+    fontWeight: FontWeight.w700,
+    fontSize: 22,
+  );
+
+  static final dayStyle = TextStyle(
+    color: Colors.grey[700],
+    fontWeight: FontWeight.w500,
+    fontSize: 22,
+  );
+
+  static final timeStyle = TextStyle(
+    color: Colors.grey[500],
+    fontWeight: FontWeight.w400,
+    fontSize: 22,
+  );
+}

--- a/lib/Upcoming_Ride.dart
+++ b/lib/Upcoming_Ride.dart
@@ -1,239 +1,87 @@
 import 'package:flutter/material.dart';
-
-class UpcomingRide extends StatefulWidget {
-  @override
-  _UpcomingRideState createState() => _UpcomingRideState();
-}
-
-class _UpcomingRideState extends State<UpcomingRide> {
-  @override
-  Widget build(BuildContext context) {
-    final monthStyle = TextStyle(
-      color: Colors.black,
-      fontWeight: FontWeight.w700,
-      letterSpacing: 0.2,
-      fontSize: 22,
-    );
-
-    final dayStyle = TextStyle(
-      color: Colors.grey[700],
-      fontWeight: FontWeight.w500,
-      letterSpacing: 0.2,
-      fontSize: 22,
-    );
-
-    final timeStyle = TextStyle(
-      color: Colors.grey[500],
-      fontWeight: FontWeight.w400,
-      letterSpacing: 0.2,
-      fontSize: 22,
-    );
-
-    final confirmationStyle = TextStyle(
-      color: Colors.green,
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-    );
-
-    final requestedStyle = TextStyle(
-      color: Colors.orangeAccent,
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-    );
-
-    return Container(
-      height: MediaQuery.of(context).size.height * 0.4,
-      child: ListView(
-        scrollDirection: Axis.horizontal,
-        children: <Widget>[
-          UpcomingRideCard(
-            rideStatus: Text('Ride Confirmed', style: confirmationStyle),
-            timeDateWidget: RichText(
-              text: TextSpan(text: 'OCT' + ' ', style: monthStyle, children: [
-                TextSpan(text: '31th' + ' ', style: dayStyle),
-                TextSpan(text: '10:00PM', style: timeStyle)
-              ]),
-            ),
-            rideInfoWidget: RideInfoWidget(
-              start: 'Uris Hall',
-              end: 'Cascadila Hall',
-            ),
-            driverInfoWidget: DriverInfoWidget(
-              driverName: 'Driver',
-              driverStatus: 'Confirmed',
-            ),
-          ),
-          Container(
-            margin: EdgeInsets.only(right: 17),
-            child: UpcomingRideCard(
-              rideStatus: Text('Ride Requested', style: requestedStyle),
-              timeDateWidget: RichText(
-                text: TextSpan(text: 'NOV' + ' ', style: monthStyle, children: [
-                  TextSpan(text: '26th' + ' ', style: dayStyle),
-                  TextSpan(text: '3:00PM', style: timeStyle)
-                ]),
-              ),
-              rideInfoWidget: RideInfoWidget(
-                start: 'Balch Hall',
-                end: 'Gates Hall',
-              ),
-              driverInfoWidget: DriverInfoWidget(
-                driverName: 'Driver',
-                driverStatus: 'TBD',
-              ),
-            ),
-          )
-        ],
-      ),
-    );
-  }
-}
-
-class RideInfoWidget extends StatelessWidget {
-  const RideInfoWidget({Key key, this.start, this.end}) : super(key: key);
-
-  final start;
-  final end;
-
-  @override
-  Widget build(BuildContext context) {
-    final fromToStyle = TextStyle(
-      color: Colors.grey[500],
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-    );
-
-    final infoStyle = TextStyle(
-      color: Colors.black,
-      fontWeight: FontWeight.w400,
-      fontSize: 20,
-    );
-
-    return Container(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            'From',
-            style: fromToStyle,
-          ),
-          Text(
-            start,
-            style: infoStyle,
-          ),
-          SizedBox(height: 7),
-          Text(
-            'To',
-            style: fromToStyle,
-          ),
-          Text(
-            end,
-            style: infoStyle,
-          )
-        ],
-      ),
-    );
-  }
-}
-
-class DriverInfoWidget extends StatelessWidget {
-  const DriverInfoWidget({Key key, this.driverName, this.driverStatus})
-      : super(key: key);
-
-  final driverName;
-  final driverStatus;
-
-  @override
-  Widget build(BuildContext context) {
-    final driverToStyle = TextStyle(
-      color: Colors.grey[500],
-      fontWeight: FontWeight.w500,
-      fontSize: 14,
-    );
-
-    final rideStatusStyle = TextStyle(
-      color: Colors.black,
-      fontWeight: FontWeight.w400,
-      fontSize: 20,
-    );
-
-    return Row(
-      children: <Widget>[
-        Icon(Icons.phone),
-        SizedBox(
-          width: 10.0,
-        ),
-        Container(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                driverName,
-                style: driverToStyle,
-              ),
-              Text(
-                driverStatus,
-                style: rideStatusStyle,
-              )
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
+import 'package:url_launcher/url_launcher.dart' as UrlLauncher;
+import 'Ride.dart';
+import 'TextThemes.dart';
 
 class UpcomingRideCard extends StatelessWidget {
-  const UpcomingRideCard(
-      {Key key,
-      this.rideStatus,
-      this.timeDateWidget,
-      this.rideInfoWidget,
-      this.driverInfoWidget})
-      : super(key: key);
+  UpcomingRideCard(this.ride);
+  final Ride ride;
 
-  final Widget rideStatus;
-  final Widget timeDateWidget;
-  final Widget rideInfoWidget;
-  final Widget driverInfoWidget;
-//  final Widget driverInfoWidget;
+  final confirmationStyle = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 10,
+  );
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: EdgeInsets.only(left: 17.0, bottom: 15.0),
-      width: MediaQuery.of(context).size.width * 0.7,
+      constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.65),
       child: Card(
         elevation: 3.0,
         child: Padding(
-          padding: const EdgeInsets.only(left: 20, top: 22, bottom: 22),
-          child: Container(
-            child: Column(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: <Widget>[
-                Container(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      rideStatus,
-                      SizedBox(height: 7),
-                      timeDateWidget,
-                    ],
-                  ),
-                ),
-                SizedBox(
-                  height: 15,
-                ),
-                rideInfoWidget,
-                SizedBox(
-                  height: 15,
-                ),
-                driverInfoWidget
-              ],
-            ),
+                ride.type == 'active' ? Text('Ride Confirmed', style: confirmationStyle.copyWith(color: Color(0xFF4CAF50))) :
+                Text('Ride Requested', style: confirmationStyle.copyWith(color: Color(0xFFFF9800))),
+                SizedBox(height: 4),
+                ride.buildStartTime(),
+                SizedBox(height: 16),
+                Text('From', style: TextThemes.directionStyle),
+                Text(ride.startLocation, style: TextThemes.rideInfoStyle),
+                SizedBox(height: 8),
+                Text('To', style: TextThemes.directionStyle),
+                Text(ride.endLocation, style: TextThemes.rideInfoStyle),
+                SizedBox(height: 16),
+                Row(
+                  children: <Widget>[
+                    GestureDetector(
+                      //TODO: replace temp phone number
+                      onTap: () => UrlLauncher.launch("tel://13232315234"),
+                      child: Container(
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(100),
+                              border: Border.all(width: 0.5, color: Colors.black.withOpacity(0.25))),
+                          child: Padding(
+                            padding: const EdgeInsets.all(5),
+                            child: Icon(Icons.phone, size: 20, color: Color(0xFF9B9B9B)),
+                          )
+                      ),
+                    ),
+                    SizedBox(width: 8),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text('Driver', style: TextStyle(fontSize: 11)),
+                        Text(ride.type == 'active' ? 'Confirmed' : 'TBD', style: TextThemes.rideInfoStyle)
+                      ],
+                    )
+                  ],
+                )
+              ]
           ),
         ),
+      ),
+    );
+  }
+}
+class UpcomingRides extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Row(
+        children: <Widget>[
+          //TODO: remove temporary data
+          UpcomingRideCard(Ride(
+            type: 'active',
+            startLocation: 'Uris Hall',
+            endLocation: 'Cascadilla Hall',
+            startTime: DateTime(2020, 10, 18, 12, 0),
+            endTime: DateTime(2020, 10, 18, 12, 15),
+          ))
+        ],
       ),
     );
   }

--- a/lib/Upcoming_Ride.dart
+++ b/lib/Upcoming_Ride.dart
@@ -1,281 +1,239 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart' as UrlLauncher;
 
-class UpcomingRide extends StatelessWidget {
+class UpcomingRide extends StatefulWidget {
+  @override
+  _UpcomingRideState createState() => _UpcomingRideState();
+}
+
+class _UpcomingRideState extends State<UpcomingRide> {
   @override
   Widget build(BuildContext context) {
-    final directionStyle = TextStyle(
-        color: Colors.grey[500],
-        fontWeight: FontWeight.w500,
-        letterSpacing: 0.2,
-        fontSize: 12,
-        height: 2
-    );
-
-    final infoStyle = TextStyle(
-        color: Colors.black,
-        fontWeight: FontWeight.w400,
-        letterSpacing: 0.2,
-        fontSize: 18,
-        height: 2
-    );
-
     final monthStyle = TextStyle(
-        color: Colors.black,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0.2,
-        fontSize: 18,
-        height: 2
+      color: Colors.black,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 0.2,
+      fontSize: 22,
     );
 
     final dayStyle = TextStyle(
-        color: Colors.grey[700],
-        fontWeight: FontWeight.w500,
-        letterSpacing: 0.2,
-        fontSize: 18,
-        height: 2
+      color: Colors.grey[700],
+      fontWeight: FontWeight.w500,
+      letterSpacing: 0.2,
+      fontSize: 22,
     );
 
     final timeStyle = TextStyle(
-        color: Colors.grey[500],
-        fontWeight: FontWeight.w400,
-        letterSpacing: 0.2,
-        fontSize: 17,
-        height: 2
+      color: Colors.grey[500],
+      fontWeight: FontWeight.w400,
+      letterSpacing: 0.2,
+      fontSize: 22,
     );
 
     final confirmationStyle = TextStyle(
-        color: Colors.green,
-        fontWeight: FontWeight.w500,
-        letterSpacing: 0.2,
-        fontSize: 12,
-        height: 2
+      color: Colors.green,
+      fontWeight: FontWeight.w500,
+      fontSize: 12,
+    );
+
+    final requestedStyle = TextStyle(
+      color: Colors.orangeAccent,
+      fontWeight: FontWeight.w500,
+      fontSize: 12,
     );
 
     return Container(
-      margin: EdgeInsets.symmetric(horizontal: 17.0),
-      height: MediaQuery.of(context).size.height * 0.36,
+      height: MediaQuery.of(context).size.height * 0.4,
       child: ListView(
         scrollDirection: Axis.horizontal,
         children: <Widget>[
-          Container(
-            margin: EdgeInsets.only(right: 15.0),
-            width: MediaQuery.of(context).size.width*0.65,
-            height: MediaQuery.of(context).size.height,
-            child: Card(
-              elevation: 3.0,
-              child: Column(
-                children: <Widget>[
-                  Container(
-                    margin: EdgeInsets.symmetric(horizontal: 15.0),
-                    child: Row(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(right: 2.0),
-                          child: Text('OCT', style: monthStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(
-                              right: 2.0, top: 1.0),
-                          child: Text('18th', style: dayStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(
-                              right: 2.0, top: 3.0),
-                          child: Text('12:00 PM', style: timeStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 12.0),
-                          child: Icon(Icons.touch_app),
-                        )
-                      ],
-                    ),
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('From', style: directionStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Uris Hall', style: infoStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('To', style: directionStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Cascadilla Hall', style: infoStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Ride Confirmed', style: confirmationStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                    margin: EdgeInsets.symmetric(horizontal: 15.0),
-                    child: Row(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8.0),
-                          child: Icon(Icons.person_pin, size: 38.0),
-                        ),
-                        SizedBox(width: 5.0),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Text('Davea Butler', style: infoStyle),
-                            Row(
-                              children: <Widget>[
-                                Icon(Icons.phone, size: 13.0,),
-                                SizedBox(width: 5.0),
-                                GestureDetector(
-                                  onTap: () => UrlLauncher.launch("tel://13232315234"),
-                                  child: Text('+1 323-231-5234', style: TextStyle(color: Colors.grey[600])),
-                                )
-                              ],
-                            )
-                          ],
-                        )
-                      ],
-                    ),
-                  )
-                ],
-              ),
+          UpcomingRideCard(
+            rideStatus: Text('Ride Confirmed', style: confirmationStyle),
+            timeDateWidget: RichText(
+              text: TextSpan(text: 'OCT' + ' ', style: monthStyle, children: [
+                TextSpan(text: '31th' + ' ', style: dayStyle),
+                TextSpan(text: '10:00PM', style: timeStyle)
+              ]),
+            ),
+            rideInfoWidget: RideInfoWidget(
+              start: 'Uris Hall',
+              end: 'Cascadila Hall',
+            ),
+            driverInfoWidget: DriverInfoWidget(
+              driverName: 'Driver',
+              driverStatus: 'Confirmed',
             ),
           ),
           Container(
-            margin: EdgeInsets.only(right: 15.0),
-            width: MediaQuery.of(context).size.width*0.65,
-            height: MediaQuery.of(context).size.height,
-            child: Card(
-              elevation: 3.0,
-              child: Column(
-                children: <Widget>[
-                  Container(
-                    margin: EdgeInsets.symmetric(horizontal: 15.0),
-                    child: Row(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(right: 2.0),
-                          child: Text('NOV', style: monthStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(
-                              right: 2.0, top: 1.0),
-                          child: Text('20th', style: dayStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(
-                              right: 2.0, top: 3.0),
-                          child: Text('1:00 PM', style: timeStyle),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 12.0),
-                          child: Icon(Icons.touch_app),
-                        )
-                      ],
-                    ),
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('From', style: directionStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Balch Hall', style: infoStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('To', style: directionStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Statler Hall', style: infoStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                      margin: EdgeInsets.symmetric(horizontal: 15.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Ride Confirmed', style: confirmationStyle)
-                        ],
-                      )
-                  ),
-                  Container(
-                    margin: EdgeInsets.symmetric(horizontal: 15.0),
-                    child: Row(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8.0),
-                          child: Icon(Icons.person_pin, size: 38.0),
-                        ),
-                        SizedBox(width: 5.0),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Text('George Michael', style: infoStyle),
-                            Row(
-                              children: <Widget>[
-                                Icon(Icons.phone, size: 13.0,),
-                                SizedBox(width: 5.0),
-                                Text('+ 323-231-5234')
-                              ],
-                            )
-                          ],
-                        )
-                      ],
-                    ),
-                  )
-                ],
+            margin: EdgeInsets.only(right: 17),
+            child: UpcomingRideCard(
+              rideStatus: Text('Ride Requested', style: requestedStyle),
+              timeDateWidget: RichText(
+                text: TextSpan(text: 'NOV' + ' ', style: monthStyle, children: [
+                  TextSpan(text: '26th' + ' ', style: dayStyle),
+                  TextSpan(text: '3:00PM', style: timeStyle)
+                ]),
+              ),
+              rideInfoWidget: RideInfoWidget(
+                start: 'Balch Hall',
+                end: 'Gates Hall',
+              ),
+              driverInfoWidget: DriverInfoWidget(
+                driverName: 'Driver',
+                driverStatus: 'TBD',
               ),
             ),
           )
         ],
+      ),
+    );
+  }
+}
+
+class RideInfoWidget extends StatelessWidget {
+  const RideInfoWidget({Key key, this.start, this.end}) : super(key: key);
+
+  final start;
+  final end;
+
+  @override
+  Widget build(BuildContext context) {
+    final fromToStyle = TextStyle(
+      color: Colors.grey[500],
+      fontWeight: FontWeight.w500,
+      fontSize: 12,
+    );
+
+    final infoStyle = TextStyle(
+      color: Colors.black,
+      fontWeight: FontWeight.w400,
+      fontSize: 20,
+    );
+
+    return Container(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'From',
+            style: fromToStyle,
+          ),
+          Text(
+            start,
+            style: infoStyle,
+          ),
+          SizedBox(height: 7),
+          Text(
+            'To',
+            style: fromToStyle,
+          ),
+          Text(
+            end,
+            style: infoStyle,
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class DriverInfoWidget extends StatelessWidget {
+  const DriverInfoWidget({Key key, this.driverName, this.driverStatus})
+      : super(key: key);
+
+  final driverName;
+  final driverStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    final driverToStyle = TextStyle(
+      color: Colors.grey[500],
+      fontWeight: FontWeight.w500,
+      fontSize: 14,
+    );
+
+    final rideStatusStyle = TextStyle(
+      color: Colors.black,
+      fontWeight: FontWeight.w400,
+      fontSize: 20,
+    );
+
+    return Row(
+      children: <Widget>[
+        Icon(Icons.phone),
+        SizedBox(
+          width: 10.0,
+        ),
+        Container(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                driverName,
+                style: driverToStyle,
+              ),
+              Text(
+                driverStatus,
+                style: rideStatusStyle,
+              )
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class UpcomingRideCard extends StatelessWidget {
+  const UpcomingRideCard(
+      {Key key,
+      this.rideStatus,
+      this.timeDateWidget,
+      this.rideInfoWidget,
+      this.driverInfoWidget})
+      : super(key: key);
+
+  final Widget rideStatus;
+  final Widget timeDateWidget;
+  final Widget rideInfoWidget;
+  final Widget driverInfoWidget;
+//  final Widget driverInfoWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(left: 17.0, bottom: 15.0),
+      width: MediaQuery.of(context).size.width * 0.7,
+      child: Card(
+        elevation: 3.0,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 20, top: 22, bottom: 22),
+          child: Container(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                Container(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      rideStatus,
+                      SizedBox(height: 7),
+                      timeDateWidget,
+                    ],
+                  ),
+                ),
+                SizedBox(
+                  height: 15,
+                ),
+                rideInfoWidget,
+                SizedBox(
+                  height: 15,
+                ),
+                driverInfoWidget
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Summary 
Jessie: The pull request provides the implementation of the Upcoming Rides section of the Home Page. I created custom widgets to make it easier and more readable to create Upcoming Ride Cards. 
Helen: Added minor UI fixes for the Upcoming Ride Cards for readability and text style reusability, added minor UI fixes for the homepage and drawer

Test Plan

Jessie:
![Screenshot_1603781093](https://user-images.githubusercontent.com/55370420/97266996-ab5f5280-17e6-11eb-9054-4dc07302df4c.png)

![Screenshot_1603781097](https://user-images.githubusercontent.com/55370420/97267021-b1edca00-17e6-11eb-8269-68b834808c18.png)

I tested the functionality by using the emulator.

Helen:
(Ignore the ride cards in my screenshots, it's because of my phone's weird aspect ratio as usual)
Top bar no longer has shadow before scrolling, and bottom bar does has shadow:
![image](https://user-images.githubusercontent.com/60579411/97276147-34898000-180d-11eb-960b-6567ad1fb5f3.png)
Top bar scrolling has shadow when scrolling
![image](https://user-images.githubusercontent.com/60579411/97276362-74e8fe00-180d-11eb-94be-a82e2ff19ee0.png)
Drawer no longer overlaps top bar
![image](https://user-images.githubusercontent.com/60579411/97276388-7e726600-180d-11eb-8799-8c6960d4e475.png)
