### PR TITLE
Fixed double menu buttons on home page

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -148,6 +148,7 @@ class Home extends StatelessWidget {
                       expandedHeight: 100,
                       collapsedHeight: 100,
                       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+                      actions: [Container()],
                       flexibleSpace: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisAlignment: MainAxisAlignment.end,


### PR DESCRIPTION
### Summary <!-- Required -->

Quick fix to remove the duplicate menu button on the home page, which has been hidden before because it was white

![image](https://user-images.githubusercontent.com/60579411/97372761-c2578080-188a-11eb-87ac-f5c61e80382d.png)

