### PR TITLE
Fixed, rearranged and documented functions for generating rides

### DIFF
--- a/lib/Ride.dart
+++ b/lib/Ride.dart
@@ -95,7 +95,7 @@ class Ride {
       late: json['late'],
       driver: json['driver'] == null ? null : json['driver'],
       edits: json['edits'] == null ? [] : List.from(json['edits']),
-      endDate: json['endDate'] == null ? null : DateTime.parse(json['endDate']),
+      endDate: json['endDate'] == null ? null : DateFormat('MM/dd/yyyy').parse(json['endDate']),
     );
   }
 


### PR DESCRIPTION
…generating rides

### Summary <!-- Required -->

- [x] fixed filter for past rides which was accidentally removed 
- [x] combined  
- [x] documented non-self-explanatory functions for generating rides

### Test Plan <!-- Required -->

Tested on my device. To check the past rides fix, created a repeating ride from 3/1 to 3/12 to overlap today's date, confirmed that only the rides from 3/1 up to right now show up.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
