### PR TITLE
Updated parsing for endDate to use new schema

### DIFF
--- a/lib/models/Ride.dart
+++ b/lib/models/Ride.dart
@@ -144,7 +144,7 @@ class Ride {
       edits: json['edits'] == null ? [] : List.from(json['edits']),
       endDate: json['endDate'] == null
           ? null
-          : DateFormat('MM/dd/yyyy').parse(json['endDate']),
+          : DateFormat('yyyy-MM-dd').parse(json['endDate']),
     );
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards updating endDate parsing for recurring rides

- [x] changed parsing for endDate to use year-month-date because backend schema was updated

### Test Plan <!-- Required -->

Created a recurring ride and confirmed it appeared in upcoming rides. Since recurring rides aren't working right now, just printed the end date to confirm it had parsed correctly.

### Notes <!-- Optional -->

Will test more thoroughly when recurring rides are fixed; this is just a quick fix because otherwise the upcoming rides section does not show up