### PR TITLE
Location selection new design

### DIFF
--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -46,6 +46,7 @@ class MyApp extends StatelessWidget {
                 context,
                 appConfig,
                 Provider.of<AuthProvider>(context, listen: false),
+                Provider.of<RiderProvider>(context, listen: false),
               );
             },
             child: ChangeNotifierProvider<RideFlowProvider>(

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -1,8 +1,9 @@
+import 'dart:math';
 import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Request_Ride_Time.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
+import 'package:carriage_rider/providers/RidesProvider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
 import 'package:provider/provider.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
@@ -130,7 +131,7 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                                             onPressed: () {
                                               if (_formKey.currentState.validate()) {
                                                 Navigator.push(context, MaterialPageRoute(
-                                                        builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
+                                                    builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
                                                 )
                                                 );
                                                 widget.ride.startLocation = fromCtrl.text;
@@ -163,20 +164,18 @@ class _RequestRideLocState extends State<RequestRideLoc> {
 
 class RequestLoc extends StatefulWidget {
   final Ride ride;
-  final TextEditingController fromCtrl;
-  final TextEditingController toCtrl;
   final bool isToLocation;
   final String label;
   final Widget page;
+  final List<String> initSuggestions;
 
   RequestLoc(
       {Key key,
         this.ride,
-        this.fromCtrl,
-        this.toCtrl,
         this.isToLocation,
         this.label,
-        this.page})
+        this.page,
+        this.initSuggestions})
       : super(key: key);
 
   @override
@@ -185,9 +184,151 @@ class RequestLoc extends StatefulWidget {
 
 class _RequestLocState extends State<RequestLoc> {
   final _formKey = GlobalKey<FormState>();
+  List<String> suggestions;
+
+  @override
+  void initState() {
+    super.initState();
+    suggestions = widget.initSuggestions;
+  }
 
   @override
   Widget build(BuildContext context) {
+    RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
+    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
+    TextEditingController toCtrl = rideFlowProvider.toCtrl;
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
+    List<String> locationNames = locationsProvider.favLocations.map((loc) => loc.name).toList();
+
+    Widget customLocationOption = GestureDetector(
+      onTap: () => {
+        Navigator.push(
+            context, new MaterialPageRoute(builder: (context) => widget.page))
+      },
+      child: Container(
+          child: Padding(
+              padding: EdgeInsets.only(top: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(widget.isToLocation ? toCtrl.text : fromCtrl.text,
+                      style: TextStyle(
+                          fontSize: 14, fontWeight: FontWeight.bold
+                      )
+                  ),
+                  Text('Ithaca, NY 14850',
+                      style: TextStyle(
+                          color: Colors.grey,
+                          fontSize: 12
+                      )
+                  ),
+                  Divider(),
+                ],
+              )
+          )
+      ),
+    );
+
+    ListView suggestionList = ListView.builder(
+      shrinkWrap: true,
+      itemCount: suggestions.length,
+      itemBuilder: (context, index) {
+        bool isFavorite = locationNames.contains(suggestions[index]);
+        return GestureDetector(
+            onTap: () {
+              if (widget.isToLocation) {
+                toCtrl.text = suggestions[index];
+              }
+              else {
+                fromCtrl.text = suggestions[index];
+              }
+              Navigator.push(
+                  context, MaterialPageRoute(builder: (context) => widget.page)
+              );
+            },
+            child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                      children: [
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            SizedBox(height: 12),
+                            Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                            Text(locationsProvider.locationByName(suggestions[index]).address,
+                                style: TextStyle(color: Colors.grey, fontSize: 12)),
+                            SizedBox(height: 12),
+                          ],
+                        ),
+                        isFavorite ? Spacer() : Container(),
+                        isFavorite ? Icon(Icons.star, size: 16) : Container()
+                      ]
+                  ),
+                  Divider(),
+                ]
+            )
+        );
+      },
+    );
+
+    return Scaffold(
+        resizeToAvoidBottomInset: true,
+        body: SafeArea(
+          child: Container(
+            margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
+            child: Column(
+              children: <Widget>[
+                BackText(),
+                SizedBox(height: 20.0),
+                Row(
+                  children: <Widget>[
+                    Flexible(
+                      child: widget.isToLocation
+                          ? Text('Where do you want to be dropped off?',
+                          style: CarriageTheme.title1)
+                          : Text('Where do you want to be picked up?',
+                          style: CarriageTheme.title1),
+                    )
+                  ],
+                ),
+                SizedBox(height: 20.0),
+                LocationField(
+                  ctrl: widget.isToLocation ? toCtrl : fromCtrl,
+                  label: widget.label,
+                  page: widget.page,
+                  updateSuggestions: (input) {
+                    setState(() {
+                      suggestions = locationsProvider.getSuggestions(input);
+                    });
+                  },
+                ),
+                SizedBox(height: 24),
+                suggestions.isEmpty ? customLocationOption : Expanded(child: suggestionList)
+              ],
+            ),
+          ),
+        )
+    );
+  }
+}
+
+class RequestRideLocConfirm extends StatefulWidget {
+  final Ride ride;
+
+  RequestRideLocConfirm({Key key, this.ride})
+      : super(key: key);
+
+  @override
+  _RequestRideLocConfirmState createState() => _RequestRideLocConfirmState();
+}
+
+class _RequestRideLocConfirmState extends State<RequestRideLocConfirm> {
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
     TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
@@ -199,15 +340,28 @@ class _RequestLocState extends State<RequestLoc> {
               margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
               child: Column(
                 children: <Widget>[
-                  BackText(),
+                  FlowCancel(),
                   SizedBox(height: 20.0),
                   Row(
                     children: <Widget>[
                       Flexible(
-                        child: widget.isToLocation
-                            ? Text('Where do you want to be dropped off?',
-                            style: CarriageTheme.title1)
-                            : Text('Where do you want to be picked up?',
+                        child: Text('Location', style: CarriageTheme.title1),
+                      )
+                    ],
+                  ),
+                  TabBarTop(
+                      colorOne: Colors.black,
+                      colorTwo: Colors.grey[350],
+                      colorThree: Colors.grey[350]),
+                  TabBarBot(
+                      colorOne: Colors.black,
+                      colorTwo: Colors.grey[350],
+                      colorThree: Colors.grey[350]),
+                  SizedBox(height: 15.0),
+                  Row(
+                    children: <Widget>[
+                      Flexible(
+                        child: Text('Review your pickup and dropoff location',
                             style: CarriageTheme.title1),
                       )
                     ],
@@ -216,14 +370,87 @@ class _RequestLocState extends State<RequestLoc> {
                   Form(
                     key: _formKey,
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
-                        LocationField(
-                          ctrl: widget.isToLocation ? toCtrl : fromCtrl,
-                          label: widget.label,
-                          page: widget.page,
+                        LocationInput(
+                          fromCtrl: fromCtrl,
+                          label: 'From',
+                          ride: widget.ride,
+                          finished: rideFlowProvider.locationsFinished(),
+                          isToLocation: false,
                         ),
+                        SizedBox(height: 10.0),
+                        Text(
+                            locationsProvider.checkLocation(fromCtrl.text)
+                                ? locationsProvider
+                                .locationByName(fromCtrl.text)
+                                .info ==
+                                null
+                                ? ' '
+                                : locationsProvider
+                                .locationByName(fromCtrl.text)
+                                .info
+                                : ' ',
+                            style: TextStyle(fontSize: 14, color: Colors.grey)),
+                        SizedBox(height: 30.0),
+                        LocationInput(
+                            toCtrl: toCtrl,
+                            label: 'To',
+                            ride: widget.ride,
+                            finished: rideFlowProvider.locationsFinished(),
+                            isToLocation: true),
+                        SizedBox(height: 10.0),
+                        Text(
+                            locationsProvider.checkLocation(toCtrl.text)
+                                ? locationsProvider
+                                .locationByName(toCtrl.text)
+                                .info ==
+                                null
+                                ? ' '
+                                : locationsProvider
+                                .locationByName(toCtrl.text)
+                                .info
+                                : ' ',
+                            style: TextStyle(fontSize: 14, color: Colors.grey)),
                       ],
                     ),
+                  ),
+                  Expanded(
+                    child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Padding(
+                            padding: const EdgeInsets.only(bottom: 30.0),
+                            child: Row(children: <Widget>[
+                              FlowBackDuo(),
+                              SizedBox(width: 50),
+                              ButtonTheme(
+                                minWidth: MediaQuery.of(context).size.width * 0.65,
+                                height: 50.0,
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(10)),
+                                child: Expanded(
+                                    child: RaisedButton(
+                                        onPressed: () {
+                                          if (_formKey.currentState.validate()) {
+                                            Navigator.push(
+                                                context,
+                                                new MaterialPageRoute(
+                                                    builder: (context) =>
+                                                        RequestRideType(
+                                                            ride: widget.ride)));
+                                            widget.ride.startLocation =
+                                                fromCtrl.text;
+                                            widget.ride.endLocation = toCtrl.text;
+                                          }
+                                        },
+                                        elevation: 2.0,
+                                        color: Colors.black,
+                                        textColor: Colors.white,
+                                        child: Text('Set Location',
+                                            style: TextStyle(
+                                                fontWeight: FontWeight.bold)))),
+                              ),
+                            ]))),
                   ),
                 ],
               ),
@@ -250,23 +477,52 @@ class LocationInput extends StatelessWidget {
       : super(key: key);
 
   Widget _locationInputField(BuildContext context) {
-    void onTap () {
-      Navigator.push(
-          context,
-          new MaterialPageRoute(
-            builder: (context) =>
-                RequestLoc(
-                    ride: ride,
-                    fromCtrl: fromCtrl,
-                    toCtrl: toCtrl,
-                    label: label,
-                    isToLocation: isToLocation,
-                    page: RequestRideLoc(ride: ride)),
-          )
-      );
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
+    RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
+
+    List<String> initSuggestions;
+    if (locationsProvider.hasLocations() && locationsProvider.hasFavLocations()) {
+      initSuggestions = [];
+      List<String> favLocations = locationsProvider.favLocations
+          .map((loc) => loc.name)
+          .toList();
+      initSuggestions.addAll(favLocations);
+      print(favLocations);
+
+      if (initSuggestions.length < 5) {
+        List<Ride> pastRides = ridesProvider.pastRides;
+        List<String> pastLocations = pastRides
+            .sublist(0, min(5 - initSuggestions.length + 1, pastRides.length))
+            .map((ride) => isToLocation ? ride.endLocation : ride.startLocation)
+            .where((loc) => !initSuggestions.contains(loc))
+            .toList();
+        print(pastLocations);
+        initSuggestions.addAll(pastLocations);
+      }
+
+      if (initSuggestions.length < 5) {
+        List<String> locations = locationsProvider.locations.map((loc) => loc.name).toList()..sort();
+        List<String> alphabeticalLocations = locations
+            .sublist(0, min(5 - initSuggestions.length + 1, locations.length))
+            .where((loc) => !initSuggestions.contains(loc))
+            .toList();
+        initSuggestions.addAll(alphabeticalLocations);
+        print(alphabeticalLocations);
+      }
     }
 
     bool screenReader = MediaQuery.of(context).accessibleNavigation;
+
+    void onTap () => Navigator.push(
+        context,
+        new MaterialPageRoute(
+          builder: (context) => RequestLoc(
+              ride: ride,
+              label: label,
+              isToLocation: isToLocation,
+              page: RequestRideLoc(ride: ride)),
+        )
+    );
 
     Widget textField = TextFormField(
       focusNode: AlwaysDisabledFocusNode(),
@@ -294,7 +550,7 @@ class LocationInput extends StatelessWidget {
       focusable: true,
       onTap: onTap,
       child: IgnorePointer(
-        child: textField
+          child: textField
       ),
     ) : textField;
   }
@@ -311,70 +567,26 @@ class LocationField extends StatelessWidget {
   final String label;
   final Function navigator;
   final Widget page;
+  final Function updateSuggestions;
 
   LocationField(
-      {Key key, this.ctrl, this.filled, this.label, this.navigator, this.page})
+      {Key key, this.ctrl, this.filled, this.label, this.navigator, this.page, this.updateSuggestions})
       : super(key: key);
 
   @override
   Widget build(context) {
-    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
-    return TypeAheadFormField(
-        textFieldConfiguration: TextFieldConfiguration(
-            controller: ctrl,
-            decoration: InputDecoration(
-              enabledBorder: UnderlineInputBorder(
-                borderSide: BorderSide(color: Colors.black, width: 2),
-              ),
-              floatingLabelBehavior: FloatingLabelBehavior.never,
-              labelText: label,
-              labelStyle: TextStyle(color: Colors.grey, fontSize: 17),
-            )),
-        suggestionsCallback: (pattern) {
-          return locationsProvider.getSuggestions(pattern);
-        },
-        itemBuilder: (context, suggestion) {
-          return ListTile(
-              title: Container(
-                  child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(suggestion, style: TextStyle(fontSize: 14)),
-                        Text(locationsProvider.locationByName(suggestion).address,
-                            style: TextStyle(color: Colors.grey, fontSize: 12)),
-                        Divider(),
-                      ])));
-        },
-        noItemsFoundBuilder: (context) => GestureDetector(
-          onTap: () => {
-            Navigator.push(
-                context, new MaterialPageRoute(builder: (context) => page))
-          },
-          child: Container(
-              child: Padding(
-                  padding: EdgeInsets.only(top: 10, left: 20, bottom: 20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(ctrl.text,
-                          style: TextStyle(
-                              fontSize: 14, fontWeight: FontWeight.bold)),
-                      Text('Ithaca NY',
-                          style: TextStyle(
-                              color: Colors.grey,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold)),
-                      Divider(),
-                    ],
-                  ))),
+    return TextFormField(
+        controller: ctrl,
+        decoration: InputDecoration(
+          enabledBorder: UnderlineInputBorder(
+            borderSide: BorderSide(color: Colors.black, width: 2),
+          ),
+          floatingLabelBehavior: FloatingLabelBehavior.never,
+          labelText: label,
+          labelStyle: TextStyle(color: Colors.grey, fontSize: 17),
         ),
-        transitionBuilder: (context, suggestionsBox, controller) {
-          return suggestionsBox;
-        },
-        onSuggestionSelected: (suggestion) {
-          ctrl.text = suggestion;
-          Navigator.push(
-              context, new MaterialPageRoute(builder: (context) => page));
+        onChanged: (input) {
+          updateSuggestions(input);
         },
         validator: (value) {
           if (value.isEmpty) {

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -197,7 +197,6 @@ class _RequestLocState extends State<RequestLoc> {
     TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
-    List<String> locationNames = locationsProvider.favLocations.map((loc) => loc.name).toList();
 
     Widget customLocationOption = GestureDetector(
       onTap: () => {
@@ -232,41 +231,37 @@ class _RequestLocState extends State<RequestLoc> {
       shrinkWrap: true,
       itemCount: suggestions.length,
       itemBuilder: (context, index) {
-        bool isFavorite = locationNames.contains(suggestions[index]);
-        return GestureDetector(
-            onTap: () {
-              if (widget.isToLocation) {
-                toCtrl.text = suggestions[index];
-              }
-              else {
-                fromCtrl.text = suggestions[index];
-              }
-              Navigator.push(
-                  context, MaterialPageRoute(builder: (context) => widget.page)
-              );
-            },
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                      children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            SizedBox(height: 12),
-                            Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
-                            Text(locationsProvider.locationByName(suggestions[index]).address,
-                                style: TextStyle(color: Colors.grey, fontSize: 12)),
-                            SizedBox(height: 12),
-                          ],
-                        ),
-                        isFavorite ? Spacer() : Container(),
-                        isFavorite ? Icon(Icons.star, size: 16) : Container()
-                      ]
-                  ),
-                  Divider(),
-                ]
-            )
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            InkWell(
+              child: Container(
+                width: double.infinity,
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                    SizedBox(height: 12),
+                    Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                    Text(locationsProvider.locationByName(suggestions[index]).address,
+                        style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    SizedBox(height: 12),
+                  ]
+                ),
+              ),
+              onTap: () {
+                if (widget.isToLocation) {
+                  toCtrl.text = suggestions[index];
+                }
+                else {
+                  fromCtrl.text = suggestions[index];
+                }
+                Navigator.push(
+                    context, MaterialPageRoute(builder: (context) => widget.page)
+                );
+              },
+            ),
+            Divider()
+          ],
         );
       },
     );
@@ -495,7 +490,6 @@ class LocationInput extends StatelessWidget {
             .map((ride) => isToLocation ? ride.endLocation : ride.startLocation)
             .where((loc) => !initSuggestions.contains(loc))
             .toList();
-        print(pastLocations);
         initSuggestions.addAll(pastLocations);
       }
 
@@ -506,7 +500,6 @@ class LocationInput extends StatelessWidget {
             .where((loc) => !initSuggestions.contains(loc))
             .toList();
         initSuggestions.addAll(alphabeticalLocations);
-        print(alphabeticalLocations);
       }
     }
 

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -236,21 +236,27 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
       shrinkWrap: true,
       itemCount: suggestions.length,
       itemBuilder: (context, index) {
+        String name = suggestions[index];
+        String address = locationsProvider.isPreset(suggestions[index]) ? locationsProvider.addressByName(suggestions[index]) : 'Ithaca, NY 14850';
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             InkWell(
               child: Container(
                 width: double.infinity,
-                child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(height: 12),
-                      Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
-                      Text(locationsProvider.isPreset(suggestions[index]) ? locationsProvider.addressByName(suggestions[index]) : suggestions[index] + ', Ithaca, NY 14850',
-                          style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      SizedBox(height: 12),
-                    ]
+                child: Semantics(
+                  label: name + ', ' + address,
+                  child: ExcludeSemantics(
+                    child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: 12),
+                          Text(name, style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                          Text(address, style: TextStyle(color: Colors.grey, fontSize: 12)),
+                          SizedBox(height: 12),
+                        ]
+                    ),
+                  ),
                 ),
               ),
               onTap: () {

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -35,6 +35,7 @@ class _RequestRideLocState extends State<RequestRideLoc> {
             child: Container(
               margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
               child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
                   FlowCancel(),
                   SizedBox(height: 20.0),
@@ -62,6 +63,10 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                       )
                     ],
                   ),
+                  rideFlowProvider.requestHadError ? Padding(
+                    padding: EdgeInsets.only(top: 8),
+                    child: Text('Invalid location(s), please try again.', style: TextStyle(color: Colors.red, fontSize: 16)),
+                  ) : Container(),
                   SizedBox(height: 20),
                   Form(
                     key: _formKey,
@@ -69,7 +74,6 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
                         LocationInput(
-                          fromCtrl: fromCtrl,
                           label: 'From',
                           ride: widget.ride,
                           finished: rideFlowProvider.locationsFinished(),
@@ -90,7 +94,6 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                             style: TextStyle(fontSize: 14, color: Colors.grey)),
                         SizedBox(height: 30.0),
                         LocationInput(
-                          toCtrl: toCtrl,
                           label: 'To',
                           ride: widget.ride,
                           finished: rideFlowProvider.locationsFinished(),
@@ -116,41 +119,39 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                     child: Align(
                         alignment: Alignment.bottomCenter,
                         child: Padding(
-                            padding: const EdgeInsets.only(bottom: 20.0),
-                            child: rideFlowProvider.locationsFinished() ? Row(
-                                children: <Widget>[
-                                  FlowBackDuo(),
-                                  SizedBox(width: 50),
-                                  ButtonTheme(
-                                    minWidth: MediaQuery.of(context).size.width * 0.65,
-                                    height: 50.0,
-                                    shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(10)),
-                                    child: Expanded(
-                                        child: RaisedButton(
-                                            onPressed: () {
-                                              if (_formKey.currentState.validate()) {
-                                                Navigator.push(context, MaterialPageRoute(
-                                                    builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
-                                                )
-                                                );
-                                                widget.ride.startLocation = fromCtrl.text;
-                                                widget.ride.endLocation = toCtrl.text;
-                                              }
-                                            },
-                                            elevation: 2.0,
-                                            color: Colors.black,
-                                            textColor: Colors.white,
-                                            child: Text('Set Location',
-                                                style: TextStyle(
-                                                    fontWeight: FontWeight.bold)
-                                            )
-                                        )
-                                    ),
+                          padding: const EdgeInsets.only(bottom: 20.0),
+                          child: rideFlowProvider.locationsFinished() ? Row(
+                              children: <Widget>[
+                                //FlowBackDuo(),
+                                //SizedBox(width: 50),
+                                ButtonTheme(
+                                  minWidth: MediaQuery.of(context).size.width * 0.65,
+                                  height: 50.0,
+                                  shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(10)),
+                                  child: Expanded(
+                                      child: RaisedButton(
+                                          onPressed: () {
+                                            if (_formKey.currentState.validate()) {
+                                              Navigator.push(context, MaterialPageRoute(
+                                                  builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
+                                              )
+                                              );
+                                              widget.ride.startLocation = fromCtrl.text;
+                                              widget.ride.endLocation = toCtrl.text;
+                                            }
+                                          },
+                                          elevation: 2.0,
+                                          color: Colors.black,
+                                          textColor: Colors.white,
+                                          child: Text('Set Location',
+                                              style: TextStyle(
+                                                  fontWeight: FontWeight.bold)
+                                          )
+                                      )
                                   ),
-                                ]) : Row(
-                                children: [FlowBack()]
-                            )
+                                ),
+                              ]) : Container(),
                         )
                     ),
                   )
@@ -162,14 +163,14 @@ class _RequestRideLocState extends State<RequestRideLoc> {
   }
 }
 
-class RequestLoc extends StatefulWidget {
+class SelectLocationPage extends StatefulWidget {
   final Ride ride;
   final bool isToLocation;
   final String label;
   final Widget page;
   final List<String> initSuggestions;
 
-  RequestLoc(
+  SelectLocationPage(
       {Key key,
         this.ride,
         this.isToLocation,
@@ -179,10 +180,10 @@ class RequestLoc extends StatefulWidget {
       : super(key: key);
 
   @override
-  _RequestLocState createState() => _RequestLocState();
+  _SelectLocationPageState createState() => _SelectLocationPageState();
 }
 
-class _RequestLocState extends State<RequestLoc> {
+class _SelectLocationPageState extends State<SelectLocationPage> {
   List<String> suggestions;
 
   @override
@@ -198,33 +199,37 @@ class _RequestLocState extends State<RequestLoc> {
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
 
-    Widget customLocationOption = GestureDetector(
-      onTap: () => {
-        Navigator.push(
-            context, new MaterialPageRoute(builder: (context) => widget.page))
-      },
-      child: Container(
-          child: Padding(
-              padding: EdgeInsets.only(top: 10),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(widget.isToLocation ? toCtrl.text : fromCtrl.text,
-                      style: TextStyle(
-                          fontSize: 14, fontWeight: FontWeight.bold
-                      )
-                  ),
-                  Text('Ithaca, NY 14850',
-                      style: TextStyle(
-                          color: Colors.grey,
-                          fontSize: 12
-                      )
-                  ),
-                  Divider(),
-                ],
-              )
-          )
-      ),
+    Widget customLocationOption = Column(
+        children: [
+          InkWell(
+            onTap: () => Navigator.pushReplacement(context, MaterialPageRoute(
+                builder: (context) => widget.page
+            )),
+            child: Container(
+                width: double.infinity,
+                child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(widget.isToLocation ? toCtrl.text : fromCtrl.text,
+                            style: TextStyle(
+                                fontSize: 14, fontWeight: FontWeight.bold
+                            )
+                        ),
+                        Text('Ithaca, NY 14850',
+                            style: TextStyle(
+                                color: Colors.grey,
+                                fontSize: 12
+                            )
+                        ),
+                      ],
+                    )
+                )
+            ),
+          ),
+          Divider()
+        ]
     );
 
     ListView suggestionList = ListView.builder(
@@ -240,12 +245,12 @@ class _RequestLocState extends State<RequestLoc> {
                 child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                    SizedBox(height: 12),
-                    Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
-                    Text(locationsProvider.locationByName(suggestions[index]).address,
-                        style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    SizedBox(height: 12),
-                  ]
+                      SizedBox(height: 12),
+                      Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                      Text(locationsProvider.locationByName(suggestions[index]).address,
+                          style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      SizedBox(height: 12),
+                    ]
                 ),
               ),
               onTap: () {
@@ -255,9 +260,9 @@ class _RequestLocState extends State<RequestLoc> {
                 else {
                   fromCtrl.text = suggestions[index];
                 }
-                Navigator.push(
-                    context, MaterialPageRoute(builder: (context) => widget.page)
-                );
+                Navigator.pushReplacement(context, MaterialPageRoute(
+                    builder: (context) => widget.page
+                ));
               },
             ),
             Divider()
@@ -307,154 +312,7 @@ class _RequestLocState extends State<RequestLoc> {
   }
 }
 
-class RequestRideLocConfirm extends StatefulWidget {
-  final Ride ride;
-
-  RequestRideLocConfirm({Key key, this.ride})
-      : super(key: key);
-
-  @override
-  _RequestRideLocConfirmState createState() => _RequestRideLocConfirmState();
-}
-
-class _RequestRideLocConfirmState extends State<RequestRideLocConfirm> {
-  final _formKey = GlobalKey<FormState>();
-
-  @override
-  Widget build(BuildContext context) {
-    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
-    RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
-    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
-    TextEditingController toCtrl = rideFlowProvider.toCtrl;
-
-    return Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: SafeArea(
-            child: Container(
-              margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
-              child: Column(
-                children: <Widget>[
-                  FlowCancel(),
-                  SizedBox(height: 20.0),
-                  Row(
-                    children: <Widget>[
-                      Flexible(
-                        child: Text('Location', style: CarriageTheme.title1),
-                      )
-                    ],
-                  ),
-                  TabBarTop(
-                      colorOne: Colors.black,
-                      colorTwo: Colors.grey[350],
-                      colorThree: Colors.grey[350]),
-                  TabBarBot(
-                      colorOne: Colors.black,
-                      colorTwo: Colors.grey[350],
-                      colorThree: Colors.grey[350]),
-                  SizedBox(height: 15.0),
-                  Row(
-                    children: <Widget>[
-                      Flexible(
-                        child: Text('Review your pickup and dropoff location',
-                            style: CarriageTheme.title1),
-                      )
-                    ],
-                  ),
-                  SizedBox(height: 20.0),
-                  Form(
-                    key: _formKey,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        LocationInput(
-                          fromCtrl: fromCtrl,
-                          label: 'From',
-                          ride: widget.ride,
-                          finished: rideFlowProvider.locationsFinished(),
-                          isToLocation: false,
-                        ),
-                        SizedBox(height: 10.0),
-                        Text(
-                            locationsProvider.checkLocation(fromCtrl.text)
-                                ? locationsProvider
-                                .locationByName(fromCtrl.text)
-                                .info ==
-                                null
-                                ? ' '
-                                : locationsProvider
-                                .locationByName(fromCtrl.text)
-                                .info
-                                : ' ',
-                            style: TextStyle(fontSize: 14, color: Colors.grey)),
-                        SizedBox(height: 30.0),
-                        LocationInput(
-                            toCtrl: toCtrl,
-                            label: 'To',
-                            ride: widget.ride,
-                            finished: rideFlowProvider.locationsFinished(),
-                            isToLocation: true),
-                        SizedBox(height: 10.0),
-                        Text(
-                            locationsProvider.checkLocation(toCtrl.text)
-                                ? locationsProvider
-                                .locationByName(toCtrl.text)
-                                .info ==
-                                null
-                                ? ' '
-                                : locationsProvider
-                                .locationByName(toCtrl.text)
-                                .info
-                                : ' ',
-                            style: TextStyle(fontSize: 14, color: Colors.grey)),
-                      ],
-                    ),
-                  ),
-                  Expanded(
-                    child: Align(
-                        alignment: Alignment.bottomCenter,
-                        child: Padding(
-                            padding: const EdgeInsets.only(bottom: 30.0),
-                            child: Row(children: <Widget>[
-                              FlowBackDuo(),
-                              SizedBox(width: 50),
-                              ButtonTheme(
-                                minWidth: MediaQuery.of(context).size.width * 0.65,
-                                height: 50.0,
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10)),
-                                child: Expanded(
-                                    child: RaisedButton(
-                                        onPressed: () {
-                                          if (_formKey.currentState.validate()) {
-                                            Navigator.push(
-                                                context,
-                                                new MaterialPageRoute(
-                                                    builder: (context) =>
-                                                        RequestRideType(
-                                                            ride: widget.ride)));
-                                            widget.ride.startLocation =
-                                                fromCtrl.text;
-                                            widget.ride.endLocation = toCtrl.text;
-                                          }
-                                        },
-                                        elevation: 2.0,
-                                        color: Colors.black,
-                                        textColor: Colors.white,
-                                        child: Text('Set Location',
-                                            style: TextStyle(
-                                                fontWeight: FontWeight.bold)))),
-                              ),
-                            ]))),
-                  ),
-                ],
-              ),
-            )));
-  }
-}
-
 class LocationInput extends StatelessWidget {
-  final TextEditingController fromCtrl;
-  final TextEditingController toCtrl;
   final Ride ride;
   final String label;
   final bool finished;
@@ -462,8 +320,6 @@ class LocationInput extends StatelessWidget {
 
   LocationInput(
       {Key key,
-        this.fromCtrl,
-        this.toCtrl,
         this.ride,
         this.label,
         this.finished,
@@ -473,16 +329,13 @@ class LocationInput extends StatelessWidget {
   Widget _locationInputField(BuildContext context) {
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
+    RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
+    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
+    TextEditingController toCtrl = rideFlowProvider.toCtrl;
 
     List<String> initSuggestions;
-    if (locationsProvider.hasLocations() && locationsProvider.hasFavLocations()) {
+    if (locationsProvider.hasLocations()) {
       initSuggestions = [];
-      List<String> favLocations = locationsProvider.favLocations
-          .map((loc) => loc.name)
-          .toList();
-      initSuggestions.addAll(favLocations);
-      print(favLocations);
-
       if (initSuggestions.length < 5) {
         List<Ride> pastRides = ridesProvider.pastRides;
         List<String> pastLocations = pastRides
@@ -505,18 +358,21 @@ class LocationInput extends StatelessWidget {
 
     bool screenReader = MediaQuery.of(context).accessibleNavigation;
 
-    void onTap () => Navigator.push(
-        context,
-        new MaterialPageRoute(
-          builder: (context) => RequestLoc(
-              ride: ride,
-              label: label,
-              isToLocation: isToLocation,
-              page: RequestRideLoc(ride: ride),
-              initSuggestions: initSuggestions
-          ),
-        )
-    );
+    void onTap () {
+      rideFlowProvider.setError(false);
+      Navigator.push(
+          context,
+          new MaterialPageRoute(
+            builder: (context) => SelectLocationPage(
+                ride: ride,
+                label: label,
+                isToLocation: isToLocation,
+                page: RequestRideLoc(ride: ride),
+                initSuggestions: initSuggestions
+            ),
+          )
+      );
+    }
 
     Widget textField = TextFormField(
       focusNode: AlwaysDisabledFocusNode(),

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -334,7 +334,13 @@ class LocationInput extends StatelessWidget {
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
 
     List<String> initSuggestions;
-    if (locationsProvider.hasLocations()) {
+    if (isToLocation && toCtrl.text != null && toCtrl.text != '') {
+      initSuggestions = locationsProvider.getSuggestions(toCtrl.text);
+    }
+    else if (!isToLocation && fromCtrl.text != null && fromCtrl.text != '') {
+      initSuggestions = locationsProvider.getSuggestions(fromCtrl.text);
+    }
+    else {
       initSuggestions = [];
       if (initSuggestions.length < 5) {
         List<Ride> pastRides = ridesProvider.pastRides;

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -199,33 +199,41 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
 
+    String input = widget.isToLocation ? toCtrl.text : fromCtrl.text;
+    String ithaca = 'Ithaca, NY 14850';
+    
     Widget customLocationOption = Column(
         children: [
           InkWell(
             onTap: () => Navigator.pushReplacement(context, MaterialPageRoute(
                 builder: (context) => widget.page
             )),
-            child: Container(
-                width: double.infinity,
-                child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: 12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(widget.isToLocation ? toCtrl.text : fromCtrl.text,
-                            style: TextStyle(
-                                fontSize: 14, fontWeight: FontWeight.bold
-                            )
+            child: Semantics(
+              label: input + ', ' + ithaca,
+              child: Container(
+                  width: double.infinity,
+                  child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: ExcludeSemantics(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(input,
+                                style: TextStyle(
+                                    fontSize: 14, fontWeight: FontWeight.bold
+                                )
+                            ),
+                            Text(ithaca,
+                                style: TextStyle(
+                                    color: Colors.grey,
+                                    fontSize: 12
+                                )
+                            ),
+                          ],
                         ),
-                        Text('Ithaca, NY 14850',
-                            style: TextStyle(
-                                color: Colors.grey,
-                                fontSize: 12
-                            )
-                        ),
-                      ],
-                    )
-                )
+                      )
+                  )
+              ),
             ),
           ),
           Divider()

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -81,7 +81,7 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                         ),
                         SizedBox(height: 10.0),
                         Text(
-                            locationsProvider.checkLocation(fromCtrl.text)
+                            locationsProvider.isPreset(fromCtrl.text)
                                 ? locationsProvider
                                 .locationByName(fromCtrl.text)
                                 .info ==
@@ -101,7 +101,7 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                         ),
                         SizedBox(height: 10.0),
                         Text(
-                            locationsProvider.checkLocation(toCtrl.text)
+                            locationsProvider.isPreset(toCtrl.text)
                                 ? locationsProvider
                                 .locationByName(toCtrl.text)
                                 .info ==
@@ -247,7 +247,7 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
                     children: [
                       SizedBox(height: 12),
                       Text(suggestions[index], style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
-                      Text(locationsProvider.locationByName(suggestions[index]).address,
+                      Text(locationsProvider.isPreset(suggestions[index]) ? locationsProvider.addressByName(suggestions[index]) : suggestions[index] + ', Ithaca, NY 14850',
                           style: TextStyle(color: Colors.grey, fontSize: 12)),
                       SizedBox(height: 12),
                     ]
@@ -345,20 +345,20 @@ class LocationInput extends StatelessWidget {
       if (initSuggestions.length < 5) {
         List<Ride> pastRides = ridesProvider.pastRides;
         List<String> pastLocations = pastRides
-            .sublist(0, min(5 - initSuggestions.length + 1, pastRides.length))
             .map((ride) => isToLocation ? ride.endLocation : ride.startLocation)
             .where((loc) => !initSuggestions.contains(loc))
+            .toSet()
             .toList();
-        initSuggestions.addAll(pastLocations);
+        List<String> suggestedPastLocations = pastLocations.sublist(0, min(5 - initSuggestions.length, pastLocations.length));
+        initSuggestions.addAll(suggestedPastLocations);
       }
-
       if (initSuggestions.length < 5) {
         List<String> locations = locationsProvider.locations.map((loc) => loc.name).toList()..sort();
         List<String> alphabeticalLocations = locations
-            .sublist(0, min(5 - initSuggestions.length + 1, locations.length))
             .where((loc) => !initSuggestions.contains(loc))
             .toList();
-        initSuggestions.addAll(alphabeticalLocations);
+        List<String> suggestedAlphabeticalLocations = alphabeticalLocations.sublist(0, min(5 - initSuggestions.length, alphabeticalLocations.length));
+        initSuggestions.addAll(suggestedAlphabeticalLocations);
       }
     }
 

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -183,7 +183,6 @@ class RequestLoc extends StatefulWidget {
 }
 
 class _RequestLocState extends State<RequestLoc> {
-  final _formKey = GlobalKey<FormState>();
   List<String> suggestions;
 
   @override
@@ -520,7 +519,9 @@ class LocationInput extends StatelessWidget {
               ride: ride,
               label: label,
               isToLocation: isToLocation,
-              page: RequestRideLoc(ride: ride)),
+              page: RequestRideLoc(ride: ride),
+              initSuggestions: initSuggestions
+          ),
         )
     );
 

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -244,10 +244,8 @@ class _ReviewRideState extends State<ReviewRide> {
                                       setState(() {
                                         requestLoading = true;
                                       });
-                                      String startLoc = locationsProvider.isPreset(widget.ride.startLocation) ? widget.ride.startLocation
-                                          : locationsProvider.locationByName(widget.ride.startLocation).id;
-                                      String endLoc = locationsProvider.isPreset(widget.ride.endLocation) ? widget.ride.endLocation
-                                          : locationsProvider.locationByName(widget.ride.endLocation).id;
+                                      String startLoc = locationsProvider.isPreset(widget.ride.startLocation) ? locationsProvider.locationByName(widget.ride.startLocation).id : widget.ride.startLocation;
+                                      String endLoc = locationsProvider.isPreset(widget.ride.endLocation) ? locationsProvider.locationByName(widget.ride.endLocation).id : widget.ride.endLocation;
                                       bool successfulRequest;
                                       if (rideFlowProvider.editing) {
                                         // fake instance for recurring ride

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -244,15 +244,15 @@ class _ReviewRideState extends State<ReviewRide> {
                                       setState(() {
                                         requestLoading = true;
                                       });
-                                      rideFlowProvider.clearControllers();
                                       String startLoc = locationsProvider.isPreset(widget.ride.startLocation) ? widget.ride.startLocation
                                           : locationsProvider.locationByName(widget.ride.startLocation).id;
                                       String endLoc = locationsProvider.isPreset(widget.ride.endLocation) ? widget.ride.endLocation
                                           : locationsProvider.locationByName(widget.ride.endLocation).id;
+                                      bool successfulRequest;
                                       if (rideFlowProvider.editing) {
                                         // fake instance for recurring ride
                                         if (widget.ride.parentRide != null) {
-                                          await rideFlowProvider.updateRecurringRide(
+                                          successfulRequest = await rideFlowProvider.updateRecurringRide(
                                               AppConfig.of(context),
                                               context,
                                               widget.ride.parentRide.id,
@@ -268,7 +268,7 @@ class _ReviewRideState extends State<ReviewRide> {
                                         }
                                         // real instance
                                         else {
-                                          await rideFlowProvider.updateRide(
+                                          successfulRequest = await rideFlowProvider.updateRide(
                                               AppConfig.of(context),
                                               context,
                                               widget.ride.id,
@@ -283,7 +283,7 @@ class _ReviewRideState extends State<ReviewRide> {
                                         }
                                       }
                                       else {
-                                        await rideFlowProvider.createRide(
+                                        successfulRequest = await rideFlowProvider.createRide(
                                             AppConfig.of(context),
                                             context,
                                             startLoc,
@@ -295,11 +295,18 @@ class _ReviewRideState extends State<ReviewRide> {
                                             endDate: widget.ride.endDate
                                         );
                                       }
-                                      Navigator.push(
-                                          context,
-                                          new MaterialPageRoute(
-                                              builder: (context) =>
-                                                  RideConfirmation()));
+                                      if (successfulRequest) {
+                                        rideFlowProvider.clearControllers();
+                                        Navigator.push(context, MaterialPageRoute(
+                                                builder: (context) => RideConfirmation()
+                                        ));
+                                      }
+                                      else {
+                                        rideFlowProvider.setError(true);
+                                        Navigator.of(context).pop();
+                                        Navigator.of(context).pop();
+                                        Navigator.of(context).pop();
+                                      }
                                     },
                                     elevation: 2.0,
                                     color: Colors.black,

--- a/lib/providers/LocationsProvider.dart
+++ b/lib/providers/LocationsProvider.dart
@@ -93,7 +93,7 @@ class LocationsProvider with ChangeNotifier {
 
     List<Location> exactQuery = locations.where((loc) => exact(loc)).toList();
     List<Location> startsWithQuery = locations.where((loc) => !exact(loc) && containsIndex(loc) == 0).toList();
-    List<Location> containsQuery = locations.where((loc) => !exact(loc) && containsIndex(loc) != 0 && loc.name.contains(lowerCaseQuery)).toList();
+    List<Location> containsQuery = locations.where((loc) => !exact(loc) && containsIndex(loc) != 0 && loc.name.toLowerCase().contains(lowerCaseQuery)).toList();
     List<Location> matches = exactQuery..addAll(startsWithQuery)..addAll(containsQuery);
     return matches.map((loc) => loc.name).toList();
   }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing selecting locations

- [x] implemented new designs for selecting locations
- [x] manually implemented search bar to return in order: exact match, contains query at start, contains query anywhere else
- [x] implemented navigation back if request fails from a bad location
- [x] removed back button in location flow because it makes it possible to back out of the ride flow entirely and   

### Test Plan <!-- Required -->
Initial suggestions:
<img src="https://scontent-iad3-2.xx.fbcdn.net/v/t1.15752-9/180793386_1454601498213039_3865461202641480923_n.png?_nc_cat=102&_nc_map=test-rt&ccb=1-3&_nc_sid=ae9488&_nc_ohc=6vtzbeWDki8AX85hxtn&_nc_ht=scontent-iad3-2.xx&oh=9e063f500e654cad620197b21c3ec126&oe=60B0ADE4" width="200"/>

Invalid locations:
<img src="https://user-images.githubusercontent.com/60579411/116645756-6efee180-a944-11eb-882e-ffd624d047ae.png" width="200"/>

Input suggestions:
<img src="https://user-images.githubusercontent.com/60579411/116645772-77571c80-a944-11eb-895b-616bedd51c58.png" width="200"/>

Suggestions:
- With 0 past locations, checked that initial location suggestions are 5 alphabetical locations
- With less than 5 past locations, checked that initial location suggestions are past locations and then alphabetical locations
- With 5 past locations, checked that initial location suggestions are 5 past locations
- With 6 past locations, checked that initial location suggestions are 5 past locations
- Checked that there are no repeated suggestions if past rides have the same location
- Checked that from and to location suggestions are set correctly

Querying:
- Checked that all locations in alphabetical order show up when query is empty
- Checked that matches show up in correct order without repetitions and regardless of case: **b** matches with **b**, then **B**alch Hall, then Physical Sciences **B**uilding and CT**B** 
<img src="https://user-images.githubusercontent.com/60579411/116650883-03bb0c80-a950-11eb-8ab9-3daa6eaef070.png" width="200"/>

Requests:
- Sent request with valid custom location and confirmed it went through
- Sent request with bad custom location and confirmed it went back to the location selection page. Changed bad custom location to valid custom location and ran through flow again, confirmed it went through

Accessibility:
- Checked new location widgets and custom widget selection with TalkBack