### PR TITLE
Cancel regular and repeating rides

### DIFF
--- a/lib/models/Ride.dart
+++ b/lib/models/Ride.dart
@@ -222,96 +222,174 @@ class Ride {
   Widget buildSummary(context) {
     RiderProvider riderProvider = Provider.of<RiderProvider>(context);
     return Column(children: [
-      Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: <Widget>[Text('From', style: CarriageTheme.caption2)]),
-      SizedBox(height: 8),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[Text(startLocation, style: CarriageTheme.infoStyle)],
-      ),
-      SizedBox(height: 16),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[Text('To', style: CarriageTheme.caption2)],
-      ),
-      SizedBox(height: 8),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[Text(endLocation, style: CarriageTheme.infoStyle)],
-      ),
-      SizedBox(height: 15),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[Text('Date', style: CarriageTheme.caption2)],
-      ),
-      SizedBox(height: 5),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          Text(DateFormat('yMd').format(startTime),
-              style: CarriageTheme.infoStyle)
-        ],
-      ),
-      SizedBox(height: 15),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          Container(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+      MergeSemantics(
+        child: Column(
+          children: [
+            Row(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
+              Text('From', style: CarriageTheme.labelStyle)
+            ]),
+            SizedBox(height: 5),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
-                Text('Pickup Time', style: CarriageTheme.caption2),
-                SizedBox(height: 5),
-                Text(DateFormat('jm').format(startTime),
-                    style: CarriageTheme.infoStyle)
+                Flexible(
+                    child: Text(startLocation,
+                        style: CarriageTheme.infoStyle))
               ],
             ),
-          ),
-          SizedBox(width: 30),
-          Container(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text('Drop-off Time', style: CarriageTheme.caption2),
+          ],
+        ),
+      ),
+      SizedBox(height: 15),
+      MergeSemantics(
+          child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[Text('To', style: CarriageTheme.labelStyle)],
+                ),
                 SizedBox(height: 5),
-                Text(DateFormat('jm').format(endTime),
-                    style: CarriageTheme.infoStyle)
-              ],
-            ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Flexible(
+                        child: Text(endLocation,
+                            style: CarriageTheme.infoStyle))
+                  ],
+                ),
+              ]
           )
-        ],
-      ),
-      SizedBox(height: 15),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[Text('Every', style: CarriageTheme.caption2)],
-      ),
-      SizedBox(height: 5),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          //TODO: change to have repeating rides info
-          Text('M W F', style: CarriageTheme.infoStyle)
-        ],
       ),
       SizedBox(height: 15),
       Row(
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
-          Text('Accessibility Request', style: CarriageTheme.caption2)
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                  child: MergeSemantics(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text('Start Date', style: CarriageTheme.labelStyle),
+                        SizedBox(height: 5),
+                        Text(DateFormat.yMd().format(startTime),
+                            style: CarriageTheme.infoStyle)
+                      ],
+                    ),
+                  )
+              ),
+              SizedBox(height: 20),
+              MergeSemantics(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Pickup Time', style: CarriageTheme.labelStyle),
+                    SizedBox(height: 5),
+                    Text(DateFormat.jm().format(startTime),
+                        style: CarriageTheme.infoStyle)
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(width: 20),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              endDate != null
+                  ? Container(
+                  child: MergeSemantics(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text('End Date', style: CarriageTheme.labelStyle),
+                        SizedBox(height: 5),
+                        Text(DateFormat.yMd().format(endDate),
+                            style: CarriageTheme.infoStyle)
+                      ],
+                    ),
+                  ))
+                  : Container(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(''),
+                      SizedBox(height: 5),
+                      Text('', style: CarriageTheme.infoStyle)
+                    ],
+                  )),
+              SizedBox(height: 20),
+              Container(
+                  child: MergeSemantics(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text('Drop-off Time',
+                            style: CarriageTheme.labelStyle),
+                        SizedBox(height: 5),
+                        Text(DateFormat.jm().format(endTime),
+                            style: CarriageTheme.infoStyle)
+                      ],
+                    ),
+                  )
+              )
+            ],
+          ),
         ],
       ),
-      SizedBox(height: 5),
-      Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          Text(
-              riderProvider.hasInfo()
-                  ? riderProvider.info.accessibilityStr()
-                  : '',
-              style: CarriageTheme.infoStyle)
-        ],
+      recurring ? Container(
+          child: MergeSemantics(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: 15),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Every', style: CarriageTheme.labelStyle)
+                  ],
+                ),
+                SizedBox(height: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text(recurringDays.map((day) {
+                      List<String> days = ['M', 'T', 'W', 'Th', 'F'];
+                      return days[day-1];
+                    }).toList().join(' '),
+                      style: CarriageTheme.infoStyle,
+                      semanticsLabel: recurringDays.map((day) {
+                        List<String> days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+                        return days[day-1];
+                      }).toList().join(' '),)
+                  ],
+                )
+              ],
+            ),
+          ))
+          : Container(),
+      SizedBox(height: 15),
+      MergeSemantics(
+          child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Accessibility Requirement',
+                        style: CarriageTheme.labelStyle)
+                  ],
+                ),
+                SizedBox(height: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text(riderProvider.info.accessibilityStr(), style: CarriageTheme.infoStyle)
+                  ],
+                ),
+              ]
+          )
       ),
     ]);
   }

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -126,7 +126,7 @@ class CancelConfirmation extends StatelessWidget {
         body: SafeArea(
             child: Column(children: [
               SizedBox(height: 176),
-              Image.asset('assets/images/cancel_ride_confirmed.png'),
+              ExcludeSemantics(child: Image.asset('assets/images/cancel_ride_confirmed.png')),
               SizedBox(height: 32),
               Center(
                   child: Text('Your ride is cancelled!',

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -1,7 +1,11 @@
+import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
 import 'package:carriage_rider/providers/AuthProvider.dart';
+import 'package:carriage_rider/providers/RidesProvider.dart';
+import 'package:carriage_rider/utils/CarriageTheme.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
+import 'package:loading_overlay/loading_overlay.dart';
 import '../utils/app_config.dart';
 import '../models/Ride.dart';
 import 'package:provider/provider.dart';
@@ -19,108 +23,103 @@ class CancelRidePage extends StatefulWidget {
 
 class _CancelRidePageState extends State<CancelRidePage> {
   bool cancelRepeating;
+  bool requestedCancel;
 
   @override
   void initState() {
     super.initState();
     setState(() {
       cancelRepeating = false;
+      requestedCancel = false;
     });
-  }
-
-  Future<void> cancelRide(BuildContext context, Ride ride) async {
-    AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
-    String token = await authProvider.secureStorage.read(key: 'token');
-    http.Response response = await http.delete(
-        AppConfig.of(context).baseUrl + '/rides/${ride.id}',
-        headers: <String, String>{
-          'Content-Type': 'application/json; charset=UTF-8',
-          HttpHeaders.authorizationHeader: 'Bearer $token'
-        });
-    if (response.statusCode == 200) {
-      Navigator.of(context).pushReplacement(MaterialPageRoute(
-          builder: (context) => CancelConfirmation())
-      );
-    }
-  }
-
-  Future<void> cancelRepeatingRideOccurrence(BuildContext context, Ride ride) async {
-    AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
-    String token = await authProvider.secureStorage.read(key: 'token');
-    Map<String, dynamic> request = <String, dynamic>{
-      'id': ride.id,
-      'deleteOnly': true,
-      'origDate': DateFormat('yyyy-MM-dd').format(ride.origDate),
-    };
-    final response = await http.put('${AppConfig.of(context).baseUrl}/rides/${ride.parentRide.id}/edits',
-        headers: <String, String>{
-          'Content-Type': 'application/json; charset=UTF-8',
-          HttpHeaders.authorizationHeader: 'Bearer $token'
-        },
-        body: jsonEncode(request));
-    if (response.statusCode != 200) {
-      throw Exception('Failed to delete instance of recurring ride: ${response.body}');
-    }
   }
 
   @override
   Widget build(BuildContext context) {
+    RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
+
     return Scaffold(
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              GestureDetector(
-                  child: Text('Cancel', style: TextStyle(fontSize: 17)),
-                  onTap: () {
-                    Navigator.of(context).pop();
-                  }),
-              SizedBox(height: 32),
-              Text('Are you sure you want to cancel this ride?',
-                  style: TextStyle(
-                      color: Colors.black,
-                      fontSize: 32,
-                      fontFamily: 'SFProDisplay',
-                      fontWeight: FontWeight.w500)),
-              SizedBox(height: 32),
-              widget.ride.buildSummary(context),
-              SizedBox(height: 32),
-              CheckboxListTile(
-                  activeColor: Color(0xFFA8A8A8),
-                  controlAffinity: ListTileControlAffinity.leading,
-                  value: cancelRepeating,
-                  onChanged: (bool newValue) {
-                    setState(() {
-                      cancelRepeating = newValue;
-                    });
-                  },
-                  title: Text('Cancel all repeating rides',
-                      style: TextStyle(
-                          fontSize: 18,
-                          color: Color(0xFFA8A8A8),
-                          fontWeight: FontWeight.normal))),
-              Spacer(),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: 18),
-                child: Container(
-                  width: double.infinity,
-                  child: FlatButton(
-                    color: Colors.black,
-                    textColor: Colors.white,
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(vertical: 14),
-                      child: Text('Cancel Ride',
-                          style:
-                          TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
-                    ),
-                    onPressed: () async {
-
-
-                    },
-                  ),
+        body: LoadingOverlay(
+          color: Colors.white,
+          isLoading: requestedCancel,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                BackText(),
+                SizedBox(height: 20),
+                Row(
+                  children: <Widget>[
+                    Flexible(
+                      child: Text('Cancel your ride', style: CarriageTheme.title1),
+                    )
+                  ],
                 ),
-              )
-            ]),
+                TabBarTop(
+                    colorOne: Colors.black,
+                    colorTwo: Colors.black,
+                    colorThree: Colors.black),
+                TabBarBot(
+                    colorOne: Colors.green,
+                    colorTwo: Colors.green,
+                    colorThree: Colors.black),
+                SizedBox(height: 30),
+                widget.ride.buildSummary(context),
+                SizedBox(height: 32),
+                widget.ride.parentRide != null ? CheckboxListTile(
+                    activeColor: CarriageTheme.gray2,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    value: cancelRepeating,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        cancelRepeating = newValue;
+                      });
+                    },
+                    title: Text('Cancel all repeating rides',
+                        style: TextStyle(
+                            fontSize: 18,
+                            color: CarriageTheme.gray2,
+                            fontWeight: FontWeight.normal))
+                ) : Container(),
+                Spacer(),
+                Center(
+                  child: ButtonTheme(
+                    minWidth:
+                    MediaQuery.of(context).size.width * 0.8,
+                    height: 50.0,
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
+                    child: RaisedButton(
+                      onPressed: () async {
+                        setState(() {
+                          requestedCancel = true;
+                        });
+                        if (cancelRepeating) {
+                          await ridesProvider.cancelRide(context, widget.ride.parentRide);
+                        }
+                        else {
+                          if (widget.ride.parentRide != null) {
+                            await ridesProvider.cancelRepeatingRideOccurrence(context, widget.ride);
+                          }
+                          else {
+                            await ridesProvider.cancelRide(context, widget.ride);
+                          }
+                        }
+
+                        Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => CancelConfirmation())
+                        );
+                      },
+                      elevation: 3.0,
+                      color: Colors.black,
+                      textColor: Colors.white,
+                      child: Text('Cancel Ride', style: CarriageTheme.button),
+                    ),
+                  ),
+                )
+              ]),
+            ),
           ),
         ));
   }
@@ -152,7 +151,7 @@ class CancelConfirmation extends StatelessWidget {
                           style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
                     ),
                     onPressed: () async {
-                      Navigator.of(context).pop();
+                      Navigator.popUntil(context, ModalRoute.withName('/'));
                     },
                   ),
                 ),

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -1,10 +1,12 @@
 import 'package:carriage_rider/providers/AuthProvider.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 import '../utils/app_config.dart';
 import '../models/Ride.dart';
 import 'package:provider/provider.dart';
 import 'dart:io';
+import 'dart:convert';
 
 class CancelRidePage extends StatefulWidget {
   CancelRidePage(this.ride);
@@ -26,79 +28,101 @@ class _CancelRidePageState extends State<CancelRidePage> {
     });
   }
 
+  Future<void> cancelRide(BuildContext context, Ride ride) async {
+    AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
+    String token = await authProvider.secureStorage.read(key: 'token');
+    http.Response response = await http.delete(
+        AppConfig.of(context).baseUrl + '/rides/${ride.id}',
+        headers: <String, String>{
+          'Content-Type': 'application/json; charset=UTF-8',
+          HttpHeaders.authorizationHeader: 'Bearer $token'
+        });
+    if (response.statusCode == 200) {
+      Navigator.of(context).pushReplacement(MaterialPageRoute(
+          builder: (context) => CancelConfirmation())
+      );
+    }
+  }
+
+  Future<void> cancelRepeatingRideOccurrence(BuildContext context, Ride ride) async {
+    AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
+    String token = await authProvider.secureStorage.read(key: 'token');
+    Map<String, dynamic> request = <String, dynamic>{
+      'id': ride.id,
+      'deleteOnly': true,
+      'origDate': DateFormat('yyyy-MM-dd').format(ride.origDate),
+    };
+    final response = await http.put('${AppConfig.of(context).baseUrl}/rides/${ride.parentRide.id}/edits',
+        headers: <String, String>{
+          'Content-Type': 'application/json; charset=UTF-8',
+          HttpHeaders.authorizationHeader: 'Bearer $token'
+        },
+        body: jsonEncode(request));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to delete instance of recurring ride: ${response.body}');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         body: SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          GestureDetector(
-              child: Text('Cancel', style: TextStyle(fontSize: 17)),
-              onTap: () {
-                Navigator.of(context).pop();
-              }),
-          SizedBox(height: 32),
-          Text('Are you sure you want to cancel this ride?',
-              style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 32,
-                  fontFamily: 'SFProDisplay',
-                  fontWeight: FontWeight.w500)),
-          SizedBox(height: 32),
-          widget.ride.buildSummary(context),
-          SizedBox(height: 32),
-          CheckboxListTile(
-              activeColor: Color(0xFFA8A8A8),
-              controlAffinity: ListTileControlAffinity.leading,
-              value: cancelRepeating,
-              onChanged: (bool newValue) {
-                setState(() {
-                  cancelRepeating = newValue;
-                });
-              },
-              title: Text('Cancel all repeating rides',
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              GestureDetector(
+                  child: Text('Cancel', style: TextStyle(fontSize: 17)),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                  }),
+              SizedBox(height: 32),
+              Text('Are you sure you want to cancel this ride?',
                   style: TextStyle(
-                      fontSize: 18,
-                      color: Color(0xFFA8A8A8),
-                      fontWeight: FontWeight.normal))),
-          Spacer(),
-          Padding(
-            padding: EdgeInsets.symmetric(horizontal: 18),
-            child: Container(
-              width: double.infinity,
-              child: FlatButton(
-                color: Colors.black,
-                textColor: Colors.white,
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 14),
-                  child: Text('Cancel Ride',
-                      style:
+                      color: Colors.black,
+                      fontSize: 32,
+                      fontFamily: 'SFProDisplay',
+                      fontWeight: FontWeight.w500)),
+              SizedBox(height: 32),
+              widget.ride.buildSummary(context),
+              SizedBox(height: 32),
+              CheckboxListTile(
+                  activeColor: Color(0xFFA8A8A8),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: cancelRepeating,
+                  onChanged: (bool newValue) {
+                    setState(() {
+                      cancelRepeating = newValue;
+                    });
+                  },
+                  title: Text('Cancel all repeating rides',
+                      style: TextStyle(
+                          fontSize: 18,
+                          color: Color(0xFFA8A8A8),
+                          fontWeight: FontWeight.normal))),
+              Spacer(),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 18),
+                child: Container(
+                  width: double.infinity,
+                  child: FlatButton(
+                    color: Colors.black,
+                    textColor: Colors.white,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 14),
+                      child: Text('Cancel Ride',
+                          style:
                           TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
+                    ),
+                    onPressed: () async {
+
+
+                    },
+                  ),
                 ),
-                onPressed: () async {
-                  AuthProvider authProvider =
-                      Provider.of<AuthProvider>(context, listen: false);
-                  String token =
-                      await authProvider.secureStorage.read(key: 'token');
-                  http.Response response = await http.delete(
-                      AppConfig.of(context).baseUrl +
-                          '/rides/${widget.ride.id}',
-                      headers: <String, String>{
-                        'Content-Type': 'application/json; charset=UTF-8',
-                        HttpHeaders.authorizationHeader: 'Bearer $token'
-                      });
-                  if (response.statusCode == 200) {
-                    Navigator.of(context).pushReplacement(MaterialPageRoute(
-                        builder: (context) => CancelConfirmation()));
-                  }
-                },
-              ),
-            ),
-          )
-        ]),
-      ),
-    ));
+              )
+            ]),
+          ),
+        ));
   }
 }
 
@@ -108,31 +132,31 @@ class CancelConfirmation extends StatelessWidget {
     return Scaffold(
         body: SafeArea(
             child: Column(children: [
-      SizedBox(height: 176),
-      Image.asset('assets/images/cancel_ride_confirmed.png'),
-      SizedBox(height: 32),
-      Center(
-          child: Text('Your ride is cancelled!',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold))),
-      Spacer(),
-      Padding(
-        padding: EdgeInsets.all(34),
-        child: Container(
-          width: double.infinity,
-          child: FlatButton(
-            color: Colors.black,
-            textColor: Colors.white,
-            child: Padding(
-              padding: EdgeInsets.symmetric(vertical: 14),
-              child: Text('Done',
-                  style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
-            ),
-            onPressed: () async {
-              Navigator.of(context).pop();
-            },
-          ),
-        ),
-      )
-    ])));
+              SizedBox(height: 176),
+              Image.asset('assets/images/cancel_ride_confirmed.png'),
+              SizedBox(height: 32),
+              Center(
+                  child: Text('Your ride is cancelled!',
+                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold))),
+              Spacer(),
+              Padding(
+                padding: EdgeInsets.all(34),
+                child: Container(
+                  width: double.infinity,
+                  child: FlatButton(
+                    color: Colors.black,
+                    textColor: Colors.white,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 14),
+                      child: Text('Done',
+                          style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
+                    ),
+                    onPressed: () async {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ),
+              )
+            ])));
   }
 }

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -1,16 +1,10 @@
 import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
-import 'package:carriage_rider/providers/AuthProvider.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:intl/intl.dart';
 import 'package:loading_overlay/loading_overlay.dart';
-import '../utils/app_config.dart';
 import '../models/Ride.dart';
 import 'package:provider/provider.dart';
-import 'dart:io';
-import 'dart:convert';
 
 class CancelRidePage extends StatefulWidget {
   CancelRidePage(this.ride);

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -292,7 +292,7 @@ class Home extends StatelessWidget {
                                     MediaQuery.of(context).size.width * 0.8,
                                 height: 50.0,
                                 shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10)),
+                                    borderRadius: BorderRadius.circular(12)),
                                 child: RaisedButton.icon(
                                   onPressed: () {
                                     rideFlowProvider.setLocControllers('', '');

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -2,9 +2,7 @@ import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Ride_Confirmation.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
-import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:loading_overlay/loading_overlay.dart';
 import 'package:provider/provider.dart';
 import 'package:carriage_rider/utils/app_config.dart';
@@ -27,7 +25,6 @@ class _ReviewRideState extends State<ReviewRide> {
   Widget build(context) {
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
-    RiderProvider riderProvider = Provider.of<RiderProvider>(context);
 
     return Scaffold(
       body: LoadingOverlay(
@@ -56,175 +53,7 @@ class _ReviewRideState extends State<ReviewRide> {
                     colorTwo: Colors.green,
                     colorThree: Colors.black),
                 SizedBox(height: 30),
-                MergeSemantics(
-                  child: Column(
-                    children: [
-                      Row(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
-                        Text('From', style: CarriageTheme.labelStyle)
-                      ]),
-                      SizedBox(height: 5),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Flexible(
-                              child: Text(widget.ride.startLocation,
-                                  style: CarriageTheme.infoStyle))
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: 15),
-                MergeSemantics(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[Text('To', style: CarriageTheme.labelStyle)],
-                      ),
-                      SizedBox(height: 5),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Flexible(
-                              child: Text(widget.ride.endLocation,
-                                  style: CarriageTheme.infoStyle))
-                        ],
-                      ),
-                    ]
-                  )
-                ),
-                SizedBox(height: 15),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: <Widget>[
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Container(
-                          child: MergeSemantics(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Text('Start Date', style: CarriageTheme.labelStyle),
-                                SizedBox(height: 5),
-                                Text(DateFormat.yMd().format(widget.ride.startTime),
-                                    style: CarriageTheme.infoStyle)
-                              ],
-                            ),
-                          )
-                        ),
-                        SizedBox(height: 20),
-                        MergeSemantics(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              Text('Pickup Time', style: CarriageTheme.labelStyle),
-                              SizedBox(height: 5),
-                              Text(DateFormat.jm().format(widget.ride.startTime),
-                                  style: CarriageTheme.infoStyle)
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    SizedBox(width: 20),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        widget.ride.endDate != null
-                            ? Container(
-                            child: MergeSemantics(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: <Widget>[
-                                  Text('End Date', style: CarriageTheme.labelStyle),
-                                  SizedBox(height: 5),
-                                  Text(DateFormat.yMd().format(widget.ride.endDate),
-                                      style: CarriageTheme.infoStyle)
-                                ],
-                              ),
-                            ))
-                            : Container(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Text(''),
-                                SizedBox(height: 5),
-                                Text('', style: CarriageTheme.infoStyle)
-                              ],
-                            )),
-                        SizedBox(height: 20),
-                        Container(
-                          child: MergeSemantics(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Text('Drop-off Time',
-                                    style: CarriageTheme.labelStyle),
-                                SizedBox(height: 5),
-                                Text(DateFormat.jm().format(widget.ride.endTime),
-                                    style: CarriageTheme.infoStyle)
-                              ],
-                            ),
-                          )
-                        )
-                      ],
-                    ),
-                  ],
-                ),
-                widget.ride.recurring ? Container(
-                    child: MergeSemantics(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          SizedBox(height: 15),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            children: <Widget>[
-                              Text('Every', style: CarriageTheme.labelStyle)
-                            ],
-                          ),
-                          SizedBox(height: 5),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            children: <Widget>[
-                              Text(widget.ride.recurringDays.map((day) {
-                                List<String> days = ['M', 'T', 'W', 'Th', 'F'];
-                                return days[day-1];
-                              }).toList().join(' '),
-                                  style: CarriageTheme.infoStyle,
-                              semanticsLabel: widget.ride.recurringDays.map((day) {
-                                List<String> days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
-                                return days[day-1];
-                              }).toList().join(' '),)
-                            ],
-                          )
-                        ],
-                      ),
-                    ))
-                    : Container(),
-                SizedBox(height: 15),
-                MergeSemantics(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text('Accessibility Requirement',
-                              style: CarriageTheme.labelStyle)
-                        ],
-                      ),
-                      SizedBox(height: 5),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Text(riderProvider.info.accessibilityStr(), style: CarriageTheme.infoStyle)
-                        ],
-                      ),
-                    ]
-                  )
-                ),
+                widget.ride.buildSummary(context),
                 Expanded(
                   child: Align(
                       alignment: Alignment.bottomCenter,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is finishes implementing cancelling rides

- [x] updated cancel ride page design
- [x] added functionality for cancelling single rides, occurrences of repeating rides, and all repeating rides
- [x] implemented design where edit and cancel buttons show up together on bottom if editable and cancellable, if only cancellable then cancel button shows up on page  

### Test Plan <!-- Required -->
<img src="https://user-images.githubusercontent.com/60579411/116649436-3e6f7580-a94d-11eb-967a-21a8f3cf3b79.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/116649445-4202fc80-a94d-11eb-88a1-609a1310acc1.png" width="300"/>

- Regular ride: confirmed there was no option for cancelling all rides, cancelled and confirmed it disappeared
- Repeating ride single occurrence: confirmed there was option for cancelling all rides but didn't check it off, cancelled a single occurrence and confirmed it disappeared
- Repeating ride all occurrences: confirmed there was option for cancelling all rides and checked it off, cancelled all occurrences and confirmed they all disappeared
- Tested with TalkBack to confirm that cancel page and confirmation page are accessible

### Notes <!-- Optional -->
The cancelling all rides button does not match the designs right now because we're a using a default widget to prevent having to add accessibility manually; will update if needed