### PR TITLE
Fix ride time selection initial time

### DIFF
--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -11,10 +11,10 @@ double toDouble(TimeOfDay myTime) => myTime.hour + myTime.minute / 60.0;
 
 DateTime assignDate() {
   DateTime now = DateTime.now();
-  DateTime compare = DateTime(now.year, now.month, now.day, 10);
-  return now.difference(compare).inMinutes >= 0
+  DateTime today10AM = DateTime(now.year, now.month, now.day, 10);
+  return now.isAfter(today10AM)
       ? DateTime(now.year, now.month, now.day + 2)
-      : DateTime(now.year, now.month, now.day);
+      : DateTime(now.year, now.month, now.day + 1);
 }
 
 class RequestRideType extends StatefulWidget {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a quick fix for the ride flow time selection. 
- [x] fixed so that if it's after 10 AM, initial date should be tomorrow
- [x] made variable names + functionality clearer 

### Test Plan <!-- Required -->
Before 10 AM: confirmed that first available date is tomorrow
After 10 AM: confirmed that first available date is day after tomorrow
