### PR TITLE
Ride flow buttons + validation styling fixes

### DIFF
--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -1,6 +1,7 @@
 import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:loading_overlay/loading_overlay.dart';
 import '../models/Ride.dart';
@@ -32,87 +33,98 @@ class _CancelRidePageState extends State<CancelRidePage> {
   Widget build(BuildContext context) {
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
 
+    double buttonHeight = 48;
+    double buttonVerticalPadding = 16;
     return Scaffold(
         body: LoadingOverlay(
           color: Colors.white,
           isLoading: requestedCancel,
           child: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                BackText(),
-                SizedBox(height: 20),
-                Row(
-                  children: <Widget>[
-                    Flexible(
-                      child: Text('Cancel your ride', style: CarriageTheme.title1),
-                    )
-                  ],
-                ),
-                TabBarTop(
-                    colorOne: Colors.black,
-                    colorTwo: Colors.black,
-                    colorThree: Colors.black),
-                TabBarBot(
-                    colorOne: Colors.green,
-                    colorTwo: Colors.green,
-                    colorThree: Colors.black),
-                SizedBox(height: 30),
-                widget.ride.buildSummary(context),
-                SizedBox(height: 32),
-                widget.ride.parentRide != null ? CheckboxListTile(
-                    activeColor: CarriageTheme.gray2,
-                    controlAffinity: ListTileControlAffinity.leading,
-                    value: cancelRepeating,
-                    onChanged: (bool newValue) {
-                      setState(() {
-                        cancelRepeating = newValue;
-                      });
-                    },
-                    title: Text('Cancel all repeating rides',
-                        style: TextStyle(
-                            fontSize: 18,
-                            color: CarriageTheme.gray2,
-                            fontWeight: FontWeight.normal))
-                ) : Container(),
-                Spacer(),
-                Center(
-                  child: ButtonTheme(
-                    minWidth:
-                    MediaQuery.of(context).size.width * 0.8,
-                    height: 50.0,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
-                    child: RaisedButton(
-                      onPressed: () async {
-                        setState(() {
-                          requestedCancel = true;
-                        });
-                        if (cancelRepeating) {
-                          await ridesProvider.cancelRide(context, widget.ride.parentRide);
-                        }
-                        else {
-                          if (widget.ride.parentRide != null) {
-                            await ridesProvider.cancelRepeatingRideOccurrence(context, widget.ride);
-                          }
-                          else {
-                            await ridesProvider.cancelRide(context, widget.ride);
-                          }
-                        }
-
-                        Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(builder: (context) => CancelConfirmation())
-                        );
-                      },
-                      elevation: 3.0,
-                      color: Colors.black,
-                      textColor: Colors.white,
-                      child: Text('Cancel Ride', style: CarriageTheme.button),
-                    ),
+            child: Stack(
+              children: [
+                SingleChildScrollView(
+                  child: Container(
+                    margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0, bottom: buttonHeight + 2*buttonVerticalPadding + 40),
+                    child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                      BackText(),
+                      SizedBox(height: 20),
+                      Row(
+                        children: <Widget>[
+                          Flexible(
+                            child: Text('Cancel your ride', style: CarriageTheme.title1),
+                          )
+                        ],
+                      ),
+                      TabBarTop(
+                          colorOne: Colors.black,
+                          colorTwo: Colors.black,
+                          colorThree: Colors.black),
+                      TabBarBot(
+                          colorOne: Colors.green,
+                          colorTwo: Colors.green,
+                          colorThree: Colors.black),
+                      SizedBox(height: 30),
+                      widget.ride.buildSummary(context),
+                      SizedBox(height: 16),
+                      widget.ride.parentRide != null ? CheckboxListTile(
+                          activeColor: CarriageTheme.gray2,
+                          controlAffinity: ListTileControlAffinity.leading,
+                          value: cancelRepeating,
+                          onChanged: (bool newValue) {
+                            setState(() {
+                              cancelRepeating = newValue;
+                            });
+                          },
+                          title: Text('Cancel all repeating rides',
+                              style: TextStyle(
+                                  fontSize: 18,
+                                  color: CarriageTheme.gray2,
+                                  fontWeight: FontWeight.normal))
+                      ) : Container(),
+                    ]),
                   ),
+                ),
+                Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Container(
+                        padding: EdgeInsets.symmetric(horizontal: 34, vertical: buttonVerticalPadding),
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                            color: Colors.white,
+                            boxShadow: [
+                              BoxShadow(
+                                  spreadRadius: 5,
+                                  blurRadius: 11,
+                                  color: Colors.black.withOpacity(0.11))
+                            ]
+                        ),
+                        child: CButton(
+                          text: 'Cancel Ride',
+                          height: buttonHeight,
+                          onPressed: () async {
+                            setState(() {
+                              requestedCancel = true;
+                            });
+                            if (cancelRepeating) {
+                              await ridesProvider.cancelRide(context, widget.ride.parentRide);
+                            }
+                            else {
+                              if (widget.ride.parentRide != null) {
+                                await ridesProvider.cancelRepeatingRideOccurrence(context, widget.ride);
+                              }
+                              else {
+                                await ridesProvider.cancelRide(context, widget.ride);
+                              }
+                            }
+                            Navigator.pushReplacement(
+                                context,
+                                MaterialPageRoute(builder: (context) => CancelConfirmation())
+                            );
+                          },
+                        )
+                    )
                 )
-              ]),
+              ],
             ),
           ),
         ));

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -8,7 +8,6 @@ import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:carriage_rider/utils/app_config.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
-import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:carriage_rider/widgets/CurrentRideCard.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/pages/Ride_History.dart';
@@ -42,9 +41,6 @@ class Home extends StatelessWidget {
         style: TextStyle(color: color, fontFamily: 'SFPro'),
       );
     }
-
-    double requestButtonHeight = 48;
-    double requestButtonVerticalPadding = 24;
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
@@ -278,7 +274,7 @@ class Home extends StatelessWidget {
                     alignment: Alignment.bottomCenter,
                     child: Container(
                       width: MediaQuery.of(context).size.width,
-                      padding: EdgeInsets.symmetric(horizontal: 34, vertical: requestButtonVerticalPadding),
+                      height: MediaQuery.of(context).size.height / 8,
                       decoration:
                           BoxDecoration(color: Colors.white, boxShadow: [
                         BoxShadow(
@@ -287,21 +283,37 @@ class Home extends StatelessWidget {
                             spreadRadius: 5,
                             color: Colors.black.withOpacity(0.11))
                       ]),
-                      child: CButton(
-                        text: 'Request Ride',
-                        height: requestButtonHeight,
-                        onPressed: () {
-                          rideFlowProvider.setLocControllers('', '');
-                          rideFlowProvider.setEditing(false);
-                          Navigator.push(context,
-                              MaterialPageRoute(
-                                  builder: (context) =>
-                                      RequestRideLoc(
-                                        ride: new Ride(),
-                                      )
-                              )
-                          );
-                        },
+                      child: Stack(
+                        children: <Widget>[
+                          Align(
+                              alignment: Alignment.center,
+                              child: ButtonTheme(
+                                minWidth:
+                                    MediaQuery.of(context).size.width * 0.8,
+                                height: 50.0,
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                                child: RaisedButton.icon(
+                                  onPressed: () {
+                                    rideFlowProvider.setLocControllers('', '');
+                                    rideFlowProvider.setEditing(false);
+                                    Navigator.push(
+                                        context,
+                                        new MaterialPageRoute(
+                                            builder: (context) =>
+                                                RequestRideLoc(
+                                                  ride: new Ride(),
+                                                )));
+                                  },
+                                  elevation: 3.0,
+                                  color: Colors.black,
+                                  textColor: Colors.white,
+                                  icon: Icon(Icons.add),
+                                  label: Text('Request Ride',
+                                      style: TextStyle(fontSize: 18)),
+                                ),
+                              )),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -8,6 +8,7 @@ import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:carriage_rider/utils/app_config.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:carriage_rider/widgets/CurrentRideCard.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/pages/Ride_History.dart';
@@ -41,6 +42,9 @@ class Home extends StatelessWidget {
         style: TextStyle(color: color, fontFamily: 'SFPro'),
       );
     }
+
+    double requestButtonHeight = 48;
+    double requestButtonVerticalPadding = 24;
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
@@ -274,7 +278,7 @@ class Home extends StatelessWidget {
                     alignment: Alignment.bottomCenter,
                     child: Container(
                       width: MediaQuery.of(context).size.width,
-                      height: MediaQuery.of(context).size.height / 8,
+                      padding: EdgeInsets.symmetric(horizontal: 34, vertical: requestButtonVerticalPadding),
                       decoration:
                           BoxDecoration(color: Colors.white, boxShadow: [
                         BoxShadow(
@@ -283,37 +287,21 @@ class Home extends StatelessWidget {
                             spreadRadius: 5,
                             color: Colors.black.withOpacity(0.11))
                       ]),
-                      child: Stack(
-                        children: <Widget>[
-                          Align(
-                              alignment: Alignment.center,
-                              child: ButtonTheme(
-                                minWidth:
-                                    MediaQuery.of(context).size.width * 0.8,
-                                height: 50.0,
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12)),
-                                child: RaisedButton.icon(
-                                  onPressed: () {
-                                    rideFlowProvider.setLocControllers('', '');
-                                    rideFlowProvider.setEditing(false);
-                                    Navigator.push(
-                                        context,
-                                        new MaterialPageRoute(
-                                            builder: (context) =>
-                                                RequestRideLoc(
-                                                  ride: new Ride(),
-                                                )));
-                                  },
-                                  elevation: 3.0,
-                                  color: Colors.black,
-                                  textColor: Colors.white,
-                                  icon: Icon(Icons.add),
-                                  label: Text('Request Ride',
-                                      style: TextStyle(fontSize: 18)),
-                                ),
-                              )),
-                        ],
+                      child: CButton(
+                        text: 'Request Ride',
+                        height: requestButtonHeight,
+                        onPressed: () {
+                          rideFlowProvider.setLocControllers('', '');
+                          rideFlowProvider.setEditing(false);
+                          Navigator.push(context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      RequestRideLoc(
+                                        ride: new Ride(),
+                                      )
+                              )
+                          );
+                        },
                       ),
                     ),
                   ),

--- a/lib/pages/ride-flow/FlowWidgets.dart
+++ b/lib/pages/ride-flow/FlowWidgets.dart
@@ -54,100 +54,90 @@ class BackText extends StatelessWidget {
 }
 
 class SelectionButton extends StatelessWidget {
-  final Widget page;
   final String text;
+  final double width;
+  final double height;
   final GestureTapCallback onPressed;
 
-  const SelectionButton({Key key, this.page, this.text, this.onPressed})
+  const SelectionButton({Key key, @required this.text, @required this.width, @required this.height, @required this.onPressed})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return ButtonTheme(
-      minWidth: MediaQuery.of(context).size.width * 0.4,
-      height: 50.0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
-      child: RaisedButton(
-        onPressed: () {
-          onPressed();
-          Navigator.push(
-              context, new MaterialPageRoute(builder: (context) => page));
-        },
-        elevation: 3.0,
-        color: Colors.white,
-        textColor: Colors.black,
-        child: Text(text,
-            style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
+    /*return Container(
+      width: width,
+      child: ButtonTheme(
+          height: height,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: RaisedButton(
+            padding: EdgeInsets.all(16),
+            color: Colors.white,
+            textColor: Colors.black,
+            child: Text(text,
+                style: CarriageTheme.button.copyWith(color: Colors.black)),
+            onPressed: onPressed,
+          )
+      ),
+    );*/
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+                blurRadius: 1,
+                spreadRadius: 0,
+                color: Colors.black.withOpacity(0.25)
+            )
+          ],
+          borderRadius: BorderRadius.circular(12)
+      ),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          onTap: onPressed,
+          child: Center(
+            child: Text(text,
+                style: CarriageTheme.button.copyWith(color: Colors.black)
+            ),
+          ),
+        ),
       ),
     );
   }
 }
 
-class FlowBack extends StatelessWidget {
-  const FlowBack({Key key}) : super(key: key);
-
+class BackArrowButton extends StatelessWidget {
+  final double size;
+  BackArrowButton(this.size);
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Align(
-          alignment: Alignment.bottomCenter,
-          child: Padding(
-              padding: const EdgeInsets.only(bottom: 30.0),
-              child: Row(
-                children: <Widget>[
-                  ButtonTheme(
-                    minWidth: MediaQuery.of(context).size.width * 0.05,
-                    height: 50.0,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10)),
-                    child: RaisedButton(
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      elevation: 2.0,
-                      color: Colors.white,
-                      child: Semantics(
-                        label: 'Back',
-                        child: Row(
-                          children: [
-                            SizedBox(width: 10),
-                            Icon(Icons.arrow_back_ios),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ))),
-    );
-  }
-}
-
-class FlowBackDuo extends StatelessWidget {
-  const FlowBackDuo({Key key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return ButtonTheme(
-        minWidth: MediaQuery.of(context).size.width * 0.05,
-        height: 50.0,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-        child: RaisedButton(
-          onPressed: () {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [CarriageTheme.boxShadow],
+          borderRadius: BorderRadius.circular(12)
+      ),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          onTap: () {
             Navigator.pop(context);
           },
-          elevation: 2.0,
-          color: Colors.white,
           child: Semantics(
-              label: 'Back',
-              child: Row(
-                children: [
-                  SizedBox(width: 5),
-                  Icon(Icons.arrow_back_ios),
-                ],
-              )
+            label: 'Back',
+            child: Padding(
+              padding: EdgeInsets.only(left: 8),
+              child: Icon(Icons.arrow_back_ios),
+            ),
           ),
-        )
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -3,6 +3,7 @@ import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Request_Ride_Time.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
 import 'package:provider/provider.dart';
@@ -29,134 +30,133 @@ class _RequestRideLocState extends State<RequestRideLoc> {
     TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
     TextEditingController toCtrl = rideFlowProvider.toCtrl;
 
+    double buttonHeight = 48;
+    double buttonVerticalPadding = 16;
+
     return Scaffold(
         resizeToAvoidBottomInset: false,
         body: SafeArea(
-            child: Container(
-              margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  FlowCancel(),
-                  SizedBox(height: 20.0),
-                  Row(
-                    children: <Widget>[
-                      Flexible(
-                        child: Text('Location', style: CarriageTheme.title1),
-                      )
-                    ],
-                  ),
-                  TabBarTop(
-                      colorOne: Colors.black,
-                      colorTwo: Colors.grey[350],
-                      colorThree: Colors.grey[350]),
-                  TabBarBot(
-                      colorOne: Colors.black,
-                      colorTwo: Colors.grey[350],
-                      colorThree: Colors.grey[350]),
-                  SizedBox(height: 15.0),
-                  Row(
-                    children: <Widget>[
-                      Flexible(
-                        child: Text((rideFlowProvider.locationsFinished() ? 'Review your ' : 'Set your ') + 'pickup and dropoff location',
-                            style: CarriageTheme.title1),
-                      )
-                    ],
-                  ),
-                  rideFlowProvider.requestHadError ? Padding(
-                    padding: EdgeInsets.only(top: 8),
-                    child: Text('Invalid location(s), please try again.', style: TextStyle(color: Colors.red, fontSize: 16)),
-                  ) : Container(),
-                  SizedBox(height: 20),
-                  Form(
-                    key: _formKey,
+            child: Stack(
+              children: [
+                SingleChildScrollView(
+                  child: Container(
+                    margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0, bottom: buttonHeight + 2*buttonVerticalPadding + 40),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
-                        LocationInput(
-                          label: 'From',
-                          ride: widget.ride,
-                          finished: rideFlowProvider.locationsFinished(),
-                          isToLocation: false,
+                        FlowCancel(),
+                        SizedBox(height: 20.0),
+                        Row(
+                          children: <Widget>[
+                            Flexible(
+                              child: Text('Location', style: CarriageTheme.title1),
+                            )
+                          ],
                         ),
-                        SizedBox(height: 10.0),
-                        Text(
-                            locationsProvider.isPreset(fromCtrl.text)
-                                ? locationsProvider
-                                .locationByName(fromCtrl.text)
-                                .info ==
-                                null
-                                ? ' '
-                                : locationsProvider
-                                .locationByName(fromCtrl.text)
-                                .info
-                                : ' ',
-                            style: TextStyle(fontSize: 14, color: Colors.grey)),
-                        SizedBox(height: 30.0),
-                        LocationInput(
-                          label: 'To',
-                          ride: widget.ride,
-                          finished: rideFlowProvider.locationsFinished(),
-                          isToLocation: true,
+                        TabBarTop(
+                            colorOne: Colors.black,
+                            colorTwo: Colors.grey[350],
+                            colorThree: Colors.grey[350]),
+                        TabBarBot(
+                            colorOne: Colors.black,
+                            colorTwo: Colors.grey[350],
+                            colorThree: Colors.grey[350]),
+                        SizedBox(height: 15.0),
+                        Row(
+                          children: <Widget>[
+                            Flexible(
+                              child: Text((rideFlowProvider.locationsFinished() ? 'Review your ' : 'Set your ') + 'pickup and dropoff location',
+                                  style: CarriageTheme.title1),
+                            )
+                          ],
                         ),
-                        SizedBox(height: 10.0),
-                        Text(
-                            locationsProvider.isPreset(toCtrl.text)
-                                ? locationsProvider
-                                .locationByName(toCtrl.text)
-                                .info ==
-                                null
-                                ? ' '
-                                : locationsProvider
-                                .locationByName(toCtrl.text)
-                                .info
-                                : ' ',
-                            style: TextStyle(fontSize: 14, color: Colors.grey)),
+                        rideFlowProvider.requestHadError ? Padding(
+                          padding: EdgeInsets.only(top: 8),
+                          child: Text('Invalid location(s), please try again.', style: TextStyle(color: Colors.red, fontSize: 16)),
+                        ) : Container(),
+                        SizedBox(height: 20),
+                        Form(
+                          key: _formKey,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              LocationInput(
+                                label: 'From',
+                                ride: widget.ride,
+                                finished: rideFlowProvider.locationsFinished(),
+                                isToLocation: false,
+                              ),
+                              SizedBox(height: 10.0),
+                              Text(
+                                  locationsProvider.isPreset(fromCtrl.text)
+                                      ? locationsProvider
+                                      .locationByName(fromCtrl.text)
+                                      .info ==
+                                      null
+                                      ? ' '
+                                      : locationsProvider
+                                      .locationByName(fromCtrl.text)
+                                      .info
+                                      : ' ',
+                                  style: TextStyle(fontSize: 14, color: Colors.grey)),
+                              SizedBox(height: 30.0),
+                              LocationInput(
+                                label: 'To',
+                                ride: widget.ride,
+                                finished: rideFlowProvider.locationsFinished(),
+                                isToLocation: true,
+                              ),
+                              SizedBox(height: 10.0),
+                              Text(
+                                  locationsProvider.isPreset(toCtrl.text)
+                                      ? locationsProvider
+                                      .locationByName(toCtrl.text)
+                                      .info ==
+                                      null
+                                      ? ' '
+                                      : locationsProvider
+                                      .locationByName(toCtrl.text)
+                                      .info
+                                      : ' ',
+                                  style: TextStyle(fontSize: 14, color: Colors.grey)),
+                            ],
+                          ),
+                        ),
                       ],
                     ),
                   ),
-                  Expanded(
-                    child: Align(
-                        alignment: Alignment.bottomCenter,
-                        child: Padding(
-                          padding: const EdgeInsets.only(bottom: 20.0),
-                          child: rideFlowProvider.locationsFinished() ? Row(
-                              children: <Widget>[
-                                //FlowBackDuo(),
-                                //SizedBox(width: 50),
-                                ButtonTheme(
-                                  minWidth: MediaQuery.of(context).size.width * 0.65,
-                                  height: 50.0,
-                                  shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(10)),
-                                  child: Expanded(
-                                      child: RaisedButton(
-                                          onPressed: () {
-                                            if (_formKey.currentState.validate()) {
-                                              Navigator.push(context, MaterialPageRoute(
-                                                  builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
-                                              )
-                                              );
-                                              widget.ride.startLocation = fromCtrl.text;
-                                              widget.ride.endLocation = toCtrl.text;
-                                            }
-                                          },
-                                          elevation: 2.0,
-                                          color: Colors.black,
-                                          textColor: Colors.white,
-                                          child: Text('Set Location',
-                                              style: TextStyle(
-                                                  fontWeight: FontWeight.bold)
-                                          )
-                                      )
-                                  ),
-                                ),
-                              ]) : Container(),
-                        )
-                    ),
-                  )
-                ],
-              ),
+                ),
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Container(
+                      padding: EdgeInsets.symmetric(horizontal: 34, vertical: buttonVerticalPadding),
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                          color: Colors.white,
+                          boxShadow: [
+                            BoxShadow(
+                                spreadRadius: 5,
+                                blurRadius: 11,
+                                color: Colors.black.withOpacity(0.11))
+                          ]
+                      ),
+                      child: CButton(
+                        text: 'Set Location',
+                        height: buttonHeight,
+                        onPressed: () {
+                          if (_formKey.currentState.validate()) {
+                            Navigator.push(context, MaterialPageRoute(
+                                builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
+                            )
+                            );
+                            widget.ride.startLocation = fromCtrl.text;
+                            widget.ride.endLocation = toCtrl.text;
+                          }
+                        },
+                      )
+                  ),
+                )
+              ],
             )
         )
     );
@@ -201,7 +201,7 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
 
     String input = widget.isToLocation ? toCtrl.text : fromCtrl.text;
     String ithaca = 'Ithaca, NY 14850';
-    
+
     Widget customLocationOption = Column(
         children: [
           InkWell(

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -406,7 +406,7 @@ class LocationInput extends StatelessWidget {
       textInputAction: TextInputAction.next,
       validator: (input) {
         if (input.isEmpty) {
-          return 'Please enter your location';
+          return 'Please enter your ' + (isToLocation ? 'drop off' : 'pick up') + ' location';
         }
         return null;
       },

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -125,6 +125,7 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
   TimeOfDay _dropOffTime = TimeOfDay.now();
   List<bool> isSelected = List.filled(5, false);
   bool hasErrors = false;
+  bool showSelectionError = false;
 
   @override
   void initState() {
@@ -184,6 +185,7 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
 
   void toggle(int index) {
     setState(() {
+      showSelectionError = false;
       isSelected[index] = !isSelected[index];
     });
   }
@@ -452,7 +454,7 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                                 ToggleButton(isSelected[4], () => toggle(4), 'F', 'Fridays'),
                               ],
                             ),
-                            isSelected.indexOf(true) == -1 ? Padding(
+                            showSelectionError && isSelected.indexOf(true) == -1 ? Padding(
                               padding: EdgeInsets.only(top: 8),
                               child: Text('Select at least one day.', style: TextStyle(color: Colors.red)),
                             ) : Container(),
@@ -485,6 +487,9 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                             text: 'Set Date & Time',
                             height: buttonsHeight,
                             onPressed: () {
+                              setState(() {
+                                showSelectionError = true;
+                              });
                               if (_formKey.currentState.validate() && (widget.ride.recurring ? isSelected.indexOf(true) >= 0 : true)) {
                                 widget.ride.startTime = assembleStartTime();
                                 widget.ride.endTime = assembleEndTime();

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -2,6 +2,7 @@ import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Review_Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/ToggleButton.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
 import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
@@ -67,20 +68,39 @@ class _RequestRideTypeState extends State<RequestRideType> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
                         SelectionButton(
-                            text: 'Yes',
-                            onPressed: () {
-                              widget.ride.recurring = true;
-                            },
-                            page: RequestRideDateTime(ride: widget.ride)),
+                          text: 'Yes',
+                          width: MediaQuery.of(context).size.width * 0.4,
+                          height: 48,
+                          onPressed: () {
+                            widget.ride.recurring = true;
+                            Navigator.push(context, MaterialPageRoute(
+                                builder: (context) => RequestRideDateTime(ride: widget.ride)
+                            ));
+                          },
+                        ),
                         SizedBox(width: 30.0),
                         SelectionButton(
                             text: 'No',
+                            width: MediaQuery.of(context).size.width * 0.4,
+                            height: 48,
                             onPressed: () {
                               widget.ride.recurring = false;
-                            },
-                            page: RequestRideDateTime(ride: widget.ride))
-                      ]),
-                  FlowBack()
+                              Navigator.push(context, MaterialPageRoute(
+                                  builder: (context) => RequestRideDateTime(ride: widget.ride)
+                              ));
+                            }
+                        )
+                      ]
+                  ),
+                  Expanded(
+                    child: Align(
+                        alignment: Alignment.bottomLeft,
+                        child: Padding(
+                          padding: EdgeInsets.only(bottom: 30),
+                          child: BackArrowButton(50),
+                        )
+                    ),
+                  )
                 ],
               ),
             )));
@@ -317,177 +337,189 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       return DateTime(startDate.year, startDate.month, startDate.day, _dropOffTime.hour, _dropOffTime.minute);
     }
 
+    double buttonsHeight = 48;
+    double buttonsVerticalPadding = 16;
+
     return Scaffold(
         resizeToAvoidBottomInset: false,
         body: SafeArea(
-          child: Container(
-            margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
-            child: Column(
-              children: <Widget>[
-                FlowCancel(),
-                SizedBox(height: 20.0),
-                Row(
-                  children: <Widget>[
-                    Flexible(
-                      child: Text('Date & Time', style: CarriageTheme.title1),
-                    )
-                  ],
-                ),
-                TabBarTop(
-                    colorOne: Colors.black,
-                    colorTwo: Colors.black,
-                    colorThree: Colors.grey[350]),
-                TabBarBot(
-                    colorOne: Colors.green,
-                    colorTwo: Colors.black,
-                    colorThree: Colors.grey[350]),
-                SizedBox(height: 15.0),
-                Row(
-                  children: <Widget>[
-                    Flexible(
-                      child: Text('When is your ride? (2/2)',
-                          style: CarriageTheme.title1),
-                    )
-                  ],
-                ),
-                SizedBox(height: 30.0),
-                Row(
-                  children: <Widget>[
-                    Text('Date & Time',
-                        style:
-                        TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                  ],
-                ),
-                Form(
-                  key: _formKey,
-                  child: widget.ride.recurring ? Column(
+          child: Stack(
+            children: [
+              SingleChildScrollView(
+                child: Container(
+                  margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0, bottom: buttonsHeight + 2*buttonsVerticalPadding + 40),
+                  child: Column(
                     children: <Widget>[
+                      FlowCancel(),
+                      SizedBox(height: 20.0),
                       Row(
                         children: <Widget>[
-                          Container(
-                              width: MediaQuery.of(context).size.width / 3,
-                              margin: EdgeInsets.only(left: 15.0),
-                              child: startDateInput
-                          ),
-                          SizedBox(width: 30),
-                          Container(
-                              width: MediaQuery.of(context).size.width / 3,
-                              margin: EdgeInsets.only(right: 15.0),
-                              child: endDateInput
-                          ),
+                          Flexible(
+                            child: Text('Date & Time', style: CarriageTheme.title1),
+                          )
                         ],
                       ),
-                      SizedBox(height: 20.0),
+                      TabBarTop(
+                          colorOne: Colors.black,
+                          colorTwo: Colors.black,
+                          colorThree: Colors.grey[350]),
+                      TabBarBot(
+                          colorOne: Colors.green,
+                          colorTwo: Colors.black,
+                          colorThree: Colors.grey[350]),
+                      SizedBox(height: 15.0),
                       Row(
                         children: <Widget>[
-                          Container(
-                              width: MediaQuery.of(context).size.width / 3,
-                              margin: EdgeInsets.only(left: 15.0),
-                              child: startTimeInput),
-                          SizedBox(width: 30.0),
-                          Container(
-                              width: MediaQuery.of(context).size.width / 3,
-                              margin: EdgeInsets.only(right: 15.0),
-                              child: endTimeInput),
+                          Flexible(
+                            child: Text('When is your ride? (2/2)',
+                                style: CarriageTheme.title1),
+                          )
                         ],
-                      )
-                    ],
-                  ) : Column(
-                    children: [
-                      startDateInput,
-                      SizedBox(height: 20.0),
-                      startTimeInput,
-                      SizedBox(height: 20.0),
-                      endTimeInput
-                    ],
-                  ),
-                ),
-                widget.ride.recurring ? Column(
-                    children: [
+                      ),
                       SizedBox(height: 30.0),
                       Row(
                         children: <Widget>[
-                          Text('Repeat Days',
+                          Text('Date & Time',
                               style:
                               TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                         ],
                       ),
-                      SizedBox(height: 15),
-                      Row(
-                        children: [
-                          ToggleButton(isSelected[0], () => toggle(0), 'M', 'Mondays'),
-                          SizedBox(width: 15),
-                          ToggleButton(isSelected[1], () => toggle(1), 'T', 'Tuesdays'),
-                          SizedBox(width: 15),
-                          ToggleButton(isSelected[2], () => toggle(2), 'W', 'Wednesdays'),
-                          SizedBox(width: 15),
-                          ToggleButton(isSelected[3], () => toggle(3), 'Th', 'Thursdays'),
-                          SizedBox(width: 15),
-                          ToggleButton(isSelected[4], () => toggle(4), 'F', 'Fridays'),
-                        ],
+                      Form(
+                        key: _formKey,
+                        child: widget.ride.recurring ? Column(
+                          children: <Widget>[
+                            Row(
+                              children: <Widget>[
+                                Container(
+                                    width: MediaQuery.of(context).size.width / 3,
+                                    margin: EdgeInsets.only(left: 15.0),
+                                    child: startDateInput
+                                ),
+                                SizedBox(width: 30),
+                                Container(
+                                    width: MediaQuery.of(context).size.width / 3,
+                                    margin: EdgeInsets.only(right: 15.0),
+                                    child: endDateInput
+                                ),
+                              ],
+                            ),
+                            SizedBox(height: 20.0),
+                            Row(
+                              children: <Widget>[
+                                Container(
+                                    width: MediaQuery.of(context).size.width / 3,
+                                    margin: EdgeInsets.only(left: 15.0),
+                                    child: startTimeInput),
+                                SizedBox(width: 30.0),
+                                Container(
+                                    width: MediaQuery.of(context).size.width / 3,
+                                    margin: EdgeInsets.only(right: 15.0),
+                                    child: endTimeInput),
+                              ],
+                            )
+                          ],
+                        ) : Column(
+                          children: [
+                            startDateInput,
+                            SizedBox(height: 20.0),
+                            startTimeInput,
+                            SizedBox(height: 20.0),
+                            endTimeInput
+                          ],
+                        ),
                       ),
-                      isSelected.indexOf(true) == -1 ? Padding(
-                        padding: EdgeInsets.only(top: 8),
-                        child: Text('Select at least one day.', style: TextStyle(color: Colors.red)),
-                      ) : Container()
-                    ]
-                ) : Container(),
-                Expanded(
-                  child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                          padding: const EdgeInsets.only(bottom: 30.0),
-                          child: Row(children: <Widget>[
-                            FlowBackDuo(),
-                            SizedBox(width: 40),
-                            ButtonTheme(
-                                minWidth:
-                                MediaQuery.of(context).size.width * 0.65,
-                                height: 50.0,
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10)),
-                                child: Expanded(
-                                  child: RaisedButton(
-                                      onPressed: () {
-                                        if (_formKey.currentState.validate() && (widget.ride.recurring ? isSelected.indexOf(true) >= 0 : true)) {
-                                          widget.ride.startTime = assembleStartTime();
-                                          widget.ride.endTime = assembleEndTime();
-                                          Navigator.push(context,
-                                              MaterialPageRoute(
-                                                  builder: (context) =>
-                                                      ReviewRide(
-                                                          ride: widget.ride
-                                                      )
-                                              )
-                                          );
-                                          if (widget.ride.recurring) {
-                                            List<int> selectedDays = [];
-                                            for (int i = 0; i < isSelected.length; i++) {
-                                              if (isSelected[i]) {
-                                                selectedDays.add(i);
-                                              }
-                                            }
-                                            widget.ride.recurringDays = selectedDays.map((index) => index+1).toList();
-                                            widget.ride.endDate = endDate;
-                                          }
-                                        }
-                                        else {
-                                          setState(() {
-                                            hasErrors = true;
-                                          });
-                                        }
-                                      },
-                                      elevation: 2.0,
-                                      color: Colors.black,
-                                      textColor: Colors.white,
-                                      child: Text('Set Date & Time',
-                                          style: TextStyle(
-                                              fontWeight: FontWeight.bold))),
-                                )),
-                          ]))),
+                      widget.ride.recurring ? Column(
+                          children: [
+                            SizedBox(height: 30.0),
+                            Row(
+                              children: <Widget>[
+                                Text('Repeat Days',
+                                    style:
+                                    TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                              ],
+                            ),
+                            SizedBox(height: 15),
+                            Row(
+                              children: [
+                                ToggleButton(isSelected[0], () => toggle(0), 'M', 'Mondays'),
+                                SizedBox(width: 15),
+                                ToggleButton(isSelected[1], () => toggle(1), 'T', 'Tuesdays'),
+                                SizedBox(width: 15),
+                                ToggleButton(isSelected[2], () => toggle(2), 'W', 'Wednesdays'),
+                                SizedBox(width: 15),
+                                ToggleButton(isSelected[3], () => toggle(3), 'Th', 'Thursdays'),
+                                SizedBox(width: 15),
+                                ToggleButton(isSelected[4], () => toggle(4), 'F', 'Fridays'),
+                              ],
+                            ),
+                            isSelected.indexOf(true) == -1 ? Padding(
+                              padding: EdgeInsets.only(top: 8),
+                              child: Text('Select at least one day.', style: TextStyle(color: Colors.red)),
+                            ) : Container(),
+                          ]
+                      ) : Container(),
+                    ],
+                  ),
                 ),
-              ],
-            ),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: buttonsVerticalPadding),
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                      color: Colors.white,
+                      boxShadow: [
+                        BoxShadow(
+                            spreadRadius: 5,
+                            blurRadius: 11,
+                            color: Colors.black.withOpacity(0.11))
+                      ]
+                  ),
+                  child: Row(
+                      children: [
+                        BackArrowButton(buttonsHeight),
+                        SizedBox(width: 24),
+                        Expanded(
+                          child: CButton(
+                            text: 'Set Date & Time',
+                            height: buttonsHeight,
+                            onPressed: () {
+                              if (_formKey.currentState.validate() && (widget.ride.recurring ? isSelected.indexOf(true) >= 0 : true)) {
+                                widget.ride.startTime = assembleStartTime();
+                                widget.ride.endTime = assembleEndTime();
+                                Navigator.push(context,
+                                    MaterialPageRoute(
+                                        builder: (context) =>
+                                            ReviewRide(
+                                                ride: widget.ride
+                                            )
+                                    )
+                                );
+                                if (widget.ride.recurring) {
+                                  List<int> selectedDays = [];
+                                  for (int i = 0; i < isSelected.length; i++) {
+                                    if (isSelected[i]) {
+                                      selectedDays.add(i);
+                                    }
+                                  }
+                                  widget.ride.recurringDays = selectedDays.map((index) => index+1).toList();
+                                  widget.ride.endDate = endDate;
+                                }
+                              }
+                              else {
+                                setState(() {
+                                  hasErrors = true;
+                                });
+                              }
+                            },
+                          ),
+                        )
+                      ]
+                  ),
+                ),
+              )
+            ],
           ),
         ));
   }

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -2,6 +2,7 @@ import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Ride_Confirmation.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:loading_overlay/loading_overlay.dart';
 import 'package:provider/provider.dart';
@@ -26,127 +27,139 @@ class _ReviewRideState extends State<ReviewRide> {
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
 
+    double buttonsHeight = 48;
+    double buttonsVerticalPadding = 16;
+
     return Scaffold(
       body: LoadingOverlay(
         color: Colors.white,
         isLoading: requestLoading,
         child: SafeArea(
-          child: Container(
-            margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0),
-            child: Column(
-              children: <Widget>[
-                FlowCancel(),
-                SizedBox(height: 20.0),
-                Row(
-                  children: <Widget>[
-                    Flexible(
-                      child: Text("Review", style: CarriageTheme.title1),
-                    )
-                  ],
+          child: Stack(
+            children: [
+              SingleChildScrollView(
+                child: Container(
+                  margin: EdgeInsets.only(top: 40.0, left: 20.0, right: 20.0, bottom: buttonsHeight + 2*buttonsVerticalPadding + 40),
+                  child: Column(
+                    children: <Widget>[
+                      FlowCancel(),
+                      SizedBox(height: 20.0),
+                      Row(
+                        children: <Widget>[
+                          Flexible(
+                            child: Text("Review", style: CarriageTheme.title1),
+                          )
+                        ],
+                      ),
+                      TabBarTop(
+                          colorOne: Colors.black,
+                          colorTwo: Colors.black,
+                          colorThree: Colors.black),
+                      TabBarBot(
+                          colorOne: Colors.green,
+                          colorTwo: Colors.green,
+                          colorThree: Colors.black),
+                      SizedBox(height: 30),
+                      widget.ride.buildSummary(context),
+                    ],
+                  ),
                 ),
-                TabBarTop(
-                    colorOne: Colors.black,
-                    colorTwo: Colors.black,
-                    colorThree: Colors.black),
-                TabBarBot(
-                    colorOne: Colors.green,
-                    colorTwo: Colors.green,
-                    colorThree: Colors.black),
-                SizedBox(height: 30),
-                widget.ride.buildSummary(context),
-                Expanded(
-                  child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                          padding: const EdgeInsets.only(bottom: 20.0),
-                          child: Row(children: <Widget>[
-                            FlowBackDuo(),
-                            SizedBox(width: 40),
-                            ButtonTheme(
-                                minWidth: MediaQuery.of(context).size.width * 0.65,
-                                height: 50.0,
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(10)),
-                                child: Expanded(
-                                  child: RaisedButton(
-                                    onPressed: () async {
-                                      setState(() {
-                                        requestLoading = true;
-                                      });
-                                      String startLoc = locationsProvider.isPreset(widget.ride.startLocation) ? locationsProvider.locationByName(widget.ride.startLocation).id : widget.ride.startLocation;
-                                      String endLoc = locationsProvider.isPreset(widget.ride.endLocation) ? locationsProvider.locationByName(widget.ride.endLocation).id : widget.ride.endLocation;
-                                      bool successfulRequest;
-                                      if (rideFlowProvider.editing) {
-                                        // fake instance for recurring ride
-                                        if (widget.ride.parentRide != null) {
-                                          successfulRequest = await rideFlowProvider.updateRecurringRide(
-                                              AppConfig.of(context),
-                                              context,
-                                              widget.ride.parentRide.id,
-                                              widget.ride.origDate,
-                                              startLoc,
-                                              endLoc,
-                                              widget.ride.startTime,
-                                              widget.ride.endTime,
-                                              widget.ride.recurring,
-                                              recurringDays: widget.ride.recurringDays,
-                                              endDate: widget.ride.endDate
-                                          );
-                                        }
-                                        // real instance
-                                        else {
-                                          successfulRequest = await rideFlowProvider.updateRide(
-                                              AppConfig.of(context),
-                                              context,
-                                              widget.ride.id,
-                                              startLoc,
-                                              endLoc,
-                                              widget.ride.startTime,
-                                              widget.ride.endTime,
-                                              widget.ride.recurring,
-                                              recurringDays: widget.ride.recurringDays,
-                                              endDate: widget.ride.endDate
-                                          );
-                                        }
-                                      }
-                                      else {
-                                        successfulRequest = await rideFlowProvider.createRide(
-                                            AppConfig.of(context),
-                                            context,
-                                            startLoc,
-                                            endLoc,
-                                            widget.ride.startTime,
-                                            widget.ride.endTime,
-                                            widget.ride.recurring,
-                                            recurringDays: widget.ride.recurringDays,
-                                            endDate: widget.ride.endDate
-                                        );
-                                      }
-                                      if (successfulRequest) {
-                                        rideFlowProvider.clearControllers();
-                                        Navigator.push(context, MaterialPageRoute(
-                                                builder: (context) => RideConfirmation()
-                                        ));
-                                      }
-                                      else {
-                                        rideFlowProvider.setError(true);
-                                        Navigator.of(context).pop();
-                                        Navigator.of(context).pop();
-                                        Navigator.of(context).pop();
-                                      }
-                                    },
-                                    elevation: 2.0,
-                                    color: Colors.black,
-                                    textColor: Colors.white,
-                                    child: Text(rideFlowProvider.editing ? 'Update Request' : 'Send Request',
-                                        style:
-                                        TextStyle(fontWeight: FontWeight.bold)),
-                                  ),
-                                )),
-                          ]))),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: buttonsVerticalPadding),
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                      color: Colors.white,
+                      boxShadow: [
+                        BoxShadow(
+                            spreadRadius: 5,
+                            blurRadius: 11,
+                            color: Colors.black.withOpacity(0.11))
+                      ]
+                  ),
+                  child: Row(
+                      children: [
+                        BackArrowButton(buttonsHeight),
+                        SizedBox(width: 24),
+                        Expanded(
+                          child: CButton(
+                            text: rideFlowProvider.editing ? 'Update Request' : 'Send Request',
+                            height: buttonsHeight,
+                            onPressed: () async {
+                              setState(() {
+                                requestLoading = true;
+                              });
+                              String startLoc = locationsProvider.isPreset(widget.ride.startLocation) ? locationsProvider.locationByName(widget.ride.startLocation).id : widget.ride.startLocation;
+                              String endLoc = locationsProvider.isPreset(widget.ride.endLocation) ? locationsProvider.locationByName(widget.ride.endLocation).id : widget.ride.endLocation;
+                              bool successfulRequest;
+                              if (rideFlowProvider.editing) {
+                                // fake instance for recurring ride
+                                if (widget.ride.parentRide != null) {
+                                  successfulRequest = await rideFlowProvider.updateRecurringRide(
+                                      AppConfig.of(context),
+                                      context,
+                                      widget.ride.parentRide.id,
+                                      widget.ride.origDate,
+                                      startLoc,
+                                      endLoc,
+                                      widget.ride.startTime,
+                                      widget.ride.endTime,
+                                      widget.ride.recurring,
+                                      recurringDays: widget.ride.recurringDays,
+                                      endDate: widget.ride.endDate
+                                  );
+                                }
+                                // real instance
+                                else {
+                                  successfulRequest = await rideFlowProvider.updateRide(
+                                      AppConfig.of(context),
+                                      context,
+                                      widget.ride.id,
+                                      startLoc,
+                                      endLoc,
+                                      widget.ride.startTime,
+                                      widget.ride.endTime,
+                                      widget.ride.recurring,
+                                      recurringDays: widget.ride.recurringDays,
+                                      endDate: widget.ride.endDate
+                                  );
+                                }
+                              }
+                              else {
+                                successfulRequest = await rideFlowProvider.createRide(
+                                    AppConfig.of(context),
+                                    context,
+                                    startLoc,
+                                    endLoc,
+                                    widget.ride.startTime,
+                                    widget.ride.endTime,
+                                    widget.ride.recurring,
+                                    recurringDays: widget.ride.recurringDays,
+                                    endDate: widget.ride.endDate
+                                );
+                              }
+                              if (successfulRequest) {
+                                rideFlowProvider.clearControllers();
+                                Navigator.push(context, MaterialPageRoute(
+                                    builder: (context) => RideConfirmation()
+                                ));
+                              }
+                              else {
+                                rideFlowProvider.setError(true);
+                                Navigator.of(context).pop();
+                                Navigator.of(context).pop();
+                                Navigator.of(context).pop();
+                              }
+                            },
+                          ),
+                        )
+                      ]
+                  ),
                 ),
-              ],
-            ),
+              )
+            ],
           ),
         ),
       ),

--- a/lib/pages/ride-flow/Ride_Confirmation.dart
+++ b/lib/pages/ride-flow/Ride_Confirmation.dart
@@ -1,5 +1,6 @@
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
+import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -55,24 +56,19 @@ class _RideConfirmationState extends State<RideConfirmation> {
           Expanded(
             child: Align(
                 alignment: Alignment.bottomCenter,
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: 30.0),
-                  child: ButtonTheme(
-                    minWidth: MediaQuery.of(context).size.width * 0.8,
-                    height: 50.0,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10)),
-                    child: RaisedButton(
-                      onPressed: () {
-                        Navigator.popUntil(context, ModalRoute.withName('/'));
-                      },
-                      elevation: 3.0,
-                      color: Colors.black,
-                      textColor: Colors.white,
-                      child: Text('Done', style: CarriageTheme.button),
-                    ),
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.only(left: 34, right: 34, bottom: 30.0),
+
+                  child: CButton(
+                    text: 'Done',
+                    height: 50,
+                    onPressed: () {
+                      Navigator.popUntil(context, ModalRoute.withName('/'));
+                    },
                   ),
-                )),
+                )
+            ),
           )
         ],
       ),

--- a/lib/widgets/Buttons.dart
+++ b/lib/widgets/Buttons.dart
@@ -1,0 +1,30 @@
+import 'package:carriage_rider/utils/CarriageTheme.dart';
+import 'package:flutter/material.dart';
+
+/// Black button with white text
+class CButton extends StatelessWidget {
+  final String text;
+  final double height;
+  final void Function() onPressed;
+
+  CButton(
+      {@required this.text,
+        @required this.height,
+        @required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return ButtonTheme(
+        height: height,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: RaisedButton(
+          padding: EdgeInsets.all(16),
+          color: Colors.black,
+          textColor: Colors.white,
+          child: Text(text,
+              style: CarriageTheme.button),
+          onPressed: onPressed,
+        )
+    );
+  }
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards fixing ride flow styling
Buttons:
- [x] added bottom containers for ride flow buttons and made the rest of the page scrollable for responsive design
- [x] edited styling for yes/no and back arrow buttons for shadow to match designs 
Validation:
- [x] changed repeat day validation to only show when the user has attempted to proceed, then to hide after user interaction with the toggle buttons - this matches the other validation interaction on the page better
- [x] added location direction (pick up/drop off) to location error text  

### Test Plan <!-- Required -->

**Location**
Small device: regular
<img src="https://user-images.githubusercontent.com/60579411/117068337-27d47000-acf9-11eb-8a71-f8968f235f4a.png" width="300"/>

Small device: with errors
<img src="https://user-images.githubusercontent.com/60579411/117068408-3d499a00-acf9-11eb-8c7e-f8fff22ddbed.png" width="300"/>

My device: regular
<img src="https://user-images.githubusercontent.com/60579411/117073298-b6e48680-acff-11eb-84b0-cbb12e08062f.png" width="300"/>

**Repeating ride**
Small device:
<img src="https://user-images.githubusercontent.com/60579411/117068447-4a668900-acf9-11eb-81c0-b473afed88aa.png" width="300"/>

**Date/time**
Small device: top of page
<img src="https://user-images.githubusercontent.com/60579411/117073513-04f98a00-ad00-11eb-8b36-c0f7847c7b7c.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/117068688-9dd8d700-acf9-11eb-80fc-aac5c425f7be.png" width="300"/>

Small device: scrolled down
<img src="https://user-images.githubusercontent.com/60579411/117073541-0dea5b80-ad00-11eb-990b-9fccaecf0fed.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/117068724-a7623f00-acf9-11eb-8f07-caa6d40c19b6.png" width="300"/>

Small device: with errors
<img src="https://user-images.githubusercontent.com/60579411/117068620-8863ad00-acf9-11eb-9f09-a7421aa6835b.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/117068666-96b1c900-acf9-11eb-8237-6116bc25655c.png" width="300"/>

My device: regular
<img src="https://user-images.githubusercontent.com/60579411/117073610-28bcd000-ad00-11eb-839a-37c13bb6e384.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/117073636-340ffb80-ad00-11eb-89fc-c64479c6bb0e.png" width="300"/>

My device: with errors 
<img src="https://user-images.githubusercontent.com/60579411/117073393-d54a8200-acff-11eb-987b-d265be918f86.png" width="300"/>
<img src="https://user-images.githubusercontent.com/60579411/117073885-9406a200-ad00-11eb-9f97-4bb1ff6a08f5.png" width="300"/>

**Review ride**
Small device
<img src="https://user-images.githubusercontent.com/60579411/117068787-b943e200-acf9-11eb-837d-77aa82f2e5ce.png" width="300"/>

My device
<img src="https://user-images.githubusercontent.com/60579411/117073915-9c5edd00-ad00-11eb-813e-e1f19503e41f.png" width="300"/>

For repeat day validation, checked that:
- error does not show when first entering the page
- error shows when set date & time button is pressed
- error hides when a button is toggled
- error does not show if de-select all days before pressing set date & time button again
