### PR TITLE
Fixed long name overflow for homepage and profile page

### DIFF
--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -41,6 +41,9 @@ class Home extends StatelessWidget {
       );
     }
 
+    double menuButtonSize = 48;
+    double headingHorizPadding = 16;
+
     return Scaffold(
       resizeToAvoidBottomInset: false,
       endDrawer: SafeArea(
@@ -120,15 +123,20 @@ class Home extends StatelessWidget {
                                       padding: const EdgeInsets.only(
                                           left: 16, right: 16, bottom: 23),
                                       child: ExcludeSemantics(
-                                        child: Text(
-                                          'Hi ' +
-                                              riderProvider.info.firstName +
-                                              '! ☀',
-                                          style: TextStyle(
-                                              color: Colors.black,
-                                              fontSize: 30,
-                                              fontFamily: 'SFPro',
-                                              fontWeight: FontWeight.w700),
+                                        child: Container(
+                                          width: MediaQuery.of(context).size.width - menuButtonSize - (headingHorizPadding * 2),
+                                          child: FittedBox(
+                                            alignment: Alignment.centerLeft,
+                                            fit: BoxFit.scaleDown,
+                                            child: Text(
+                                              'Hi ' + riderProvider.info.firstName + '! ☀',
+                                              style: TextStyle(
+                                                  color: Colors.black,
+                                                  fontSize: 30,
+                                                  fontFamily: 'SFPro',
+                                                  fontWeight: FontWeight.w700),
+                                            ),
+                                          ),
                                         ),
                                       ),
                                     ),
@@ -139,12 +147,16 @@ class Home extends StatelessWidget {
                                     child: Builder(builder: (context) {
                                       return Semantics(
                                         label: 'Menu',
-                                        child: IconButton(
-                                            icon: Icon(Icons.menu,
-                                                color: Colors.black),
-                                            onPressed: () =>
-                                                Scaffold.of(context)
-                                                    .openEndDrawer()),
+                                        child: Container(
+                                          width: 48,
+                                          height: 48,
+                                          child: IconButton(
+                                              icon: Icon(Icons.menu,
+                                                  color: Colors.black),
+                                              onPressed: () =>
+                                                  Scaffold.of(context)
+                                                      .openEndDrawer()),
+                                        ),
                                       );
                                     }),
                                   )

--- a/lib/pages/Profile.dart
+++ b/lib/pages/Profile.dart
@@ -130,23 +130,26 @@ class Profile extends StatelessWidget {
                                 top: _picDiameter * 0.66)
                           ],
                         )),
-                    Column(
-                      children: [
-                        Text(riderProvider.info.fullName(),
-                            style: TextStyle(
-                              fontSize: 22,
-                              fontWeight: FontWeight.bold,
-                            )),
-                        SizedBox(height: 4),
-                        Semantics(
-                          container: true,
-                          child: Text('Joined ' + riderProvider.info.joinDate,
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(riderProvider.info.fullName(),
                               style: TextStyle(
-                                fontSize: 14,
-                                color: Theme.of(context).accentColor,
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
                               )),
-                        )
-                      ],
+                          SizedBox(height: 4),
+                          Semantics(
+                            container: true,
+                            child: Text('Joined ' + riderProvider.info.joinDate,
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: Theme.of(context).accentColor,
+                                )),
+                          )
+                        ],
+                      ),
                     )
                   ]))),
               sectionDivider,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards fixing overflow for long names

- [x] on homepage, changed name to resize to fit available space
- [x] on profile, changed name to wrap 

### Test Plan <!-- Required -->
Homepage for short name:
<img src="https://user-images.githubusercontent.com/60579411/117738830-ee08db00-b1ca-11eb-840a-ed82bdfce2b8.png" width="300"/>

Profile for short name:
<img src="https://user-images.githubusercontent.com/60579411/117738895-0d076d00-b1cb-11eb-87aa-4247c8293ef4.png" width="300"/>

Homepage for long names:
<img src="https://user-images.githubusercontent.com/60579411/117738852-f7924300-b1ca-11eb-970b-437746be2e46.png" width="300"/>

Profile for long name (checked that it doesn't break mid-name):
![image]()

<img src="https://user-images.githubusercontent.com/60579411/117738868-02e56e80-b1cb-11eb-8661-4b638e9195b9.png" width="300"/>