### PR TITLE
Ride flow state and validation refactor

### DIFF
--- a/lib/models/Ride.dart
+++ b/lib/models/Ride.dart
@@ -178,7 +178,7 @@ class Ride {
   //Widget displaying the information of a ride after it has been requested. Shows the ride's
   //start location, end location, date, start and end time, recurring days,
   //and accessibility requests.
-  Widget buildSummary(context) {
+  Widget buildSummary(BuildContext context, bool showRecurringInfo) {
     RiderProvider riderProvider = Provider.of<RiderProvider>(context);
     return Column(children: [
       MergeSemantics(
@@ -231,7 +231,7 @@ class Ride {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
-                        Text('Start Date', style: CarriageTheme.labelStyle),
+                        Text(showRecurringInfo ? 'Start Date' : 'Date', style: CarriageTheme.labelStyle),
                         SizedBox(height: 5),
                         Text(DateFormat.yMd().format(startTime),
                             style: CarriageTheme.infoStyle)
@@ -257,8 +257,7 @@ class Ride {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              endDate != null
-                  ? Container(
+              showRecurringInfo ? Container(
                   child: MergeSemantics(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -298,7 +297,7 @@ class Ride {
           ),
         ],
       ),
-      recurring ? Container(
+      showRecurringInfo ? Container(
           child: MergeSemantics(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/models/Ride.dart
+++ b/lib/models/Ride.dart
@@ -352,27 +352,4 @@ class Ride {
       ),
     ]);
   }
-
-  Ride copy() {
-    return Ride(
-        id: this.id,
-        parentRide: this.parentRide,
-        origDate: this.origDate,
-        type: this.type,
-        rider: this.rider,
-        status: this.status,
-        startLocation: this.startLocation,
-        startAddress: this.startAddress,
-        endLocation: this.endLocation,
-        endAddress: this.endAddress,
-        startTime: this.startTime,
-        endTime: this.endTime,
-        recurring: this.recurring,
-        recurringDays: this.recurringDays,
-        deleted: this.deleted,
-        late: this.late,
-        edits: this.edits,
-        endDate: this.endDate,
-        driver: this.driver);
-  }
 }

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -32,7 +32,6 @@ class _CancelRidePageState extends State<CancelRidePage> {
   @override
   Widget build(BuildContext context) {
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
-
     double buttonHeight = 48;
     double buttonVerticalPadding = 16;
     return Scaffold(
@@ -64,9 +63,9 @@ class _CancelRidePageState extends State<CancelRidePage> {
                           colorTwo: Colors.green,
                           colorThree: Colors.black),
                       SizedBox(height: 30),
-                      widget.ride.buildSummary(context),
+                      widget.ride.buildSummary(context, false),
                       SizedBox(height: 16),
-                      widget.ride.parentRide != null ? CheckboxListTile(
+                      widget.ride.parentRide != null || widget.ride.recurring ? CheckboxListTile(
                           activeColor: CarriageTheme.gray2,
                           controlAffinity: ListTileControlAffinity.leading,
                           value: cancelRepeating,
@@ -106,10 +105,10 @@ class _CancelRidePageState extends State<CancelRidePage> {
                               requestedCancel = true;
                             });
                             if (cancelRepeating) {
-                              await ridesProvider.cancelRide(context, widget.ride);
+                              await ridesProvider.cancelRide(context, widget.ride.recurring ? widget.ride : widget.ride.parentRide);
                             }
                             else {
-                              if (widget.ride.parentRide != null) {
+                              if (widget.ride.parentRide != null || widget.ride.recurring) {
                                 await ridesProvider.cancelRepeatingRideOccurrence(context, widget.ride);
                               }
                               else {

--- a/lib/pages/Cancel_Ride.dart
+++ b/lib/pages/Cancel_Ride.dart
@@ -106,7 +106,7 @@ class _CancelRidePageState extends State<CancelRidePage> {
                               requestedCancel = true;
                             });
                             if (cancelRepeating) {
-                              await ridesProvider.cancelRide(context, widget.ride.parentRide);
+                              await ridesProvider.cancelRide(context, widget.ride);
                             }
                             else {
                               if (widget.ride.parentRide != null) {

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -5,7 +5,6 @@ import 'dart:convert';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:carriage_rider/pages/ride-flow/Request_Ride_Loc.dart';
-import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/providers/AuthProvider.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
 import 'package:carriage_rider/pages/Notifications.dart';

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -628,14 +628,13 @@ class _HomeState extends State<Home> {
                                 borderRadius: BorderRadius.circular(12)),
                             child: RaisedButton.icon(
                               onPressed: () {
-                                rideFlowProvider.setLocControllers('', '');
-                                rideFlowProvider.setEditing(false);
+                                rideFlowProvider.clear();
+                                rideFlowProvider.setCreating();
                                 Navigator.push(
                                     context,
-                                    new MaterialPageRoute(
+                                    MaterialPageRoute(
                                         builder: (context) =>
-                                            RequestRideLoc(
-                                                ride: new Ride())));
+                                            RequestRideLoc()));
                               },
                               elevation: 3.0,
                               color: Colors.black,

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -463,6 +463,7 @@ class _HomeState extends State<Home> {
                             ) : Container()
                           ]),
                     ),
+                    SizedBox(height: 12),
                     Semantics(
                         sortKey: OrdinalSortKey(7),
                         child: UpcomingRides()

--- a/lib/pages/RidePage.dart
+++ b/lib/pages/RidePage.dart
@@ -264,7 +264,7 @@ class RideActions extends StatelessWidget {
 
     void editSingle(BuildContext context, Ride ride) {
       print(ride.id);
-      rideFlowProvider.setEditing(context, ride);
+      rideFlowProvider.setEditingSingle(context, ride);
       Navigator.push(
           context,
           MaterialPageRoute(
@@ -272,7 +272,7 @@ class RideActions extends StatelessWidget {
     }
 
     void editAll(BuildContext context, Ride parentRide) {
-      rideFlowProvider.setEditing(context, parentRide);
+      rideFlowProvider.setEditingAll(context, parentRide);
       Navigator.push(
           context,
           MaterialPageRoute(
@@ -292,7 +292,12 @@ class RideActions extends StatelessWidget {
           child: Text('Edit This Ride',
               style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
           onPressed: () {
-            rideFlowProvider.setEditing(context, ride);
+            if (ride.parentRide != null || ride.recurring) {
+              rideFlowProvider.setEditingRecurringSingle(context, ride);
+            }
+            else {
+              rideFlowProvider.setEditingSingle(context, ride);
+            }
             Navigator.push(
                 context,
                 MaterialPageRoute(
@@ -314,7 +319,15 @@ class RideActions extends StatelessWidget {
           child: Text('Edit All Repeating Rides',
               style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
           onPressed: () {
-            editAll(context, ride.parentRide);
+            if (ride.parentRide != null) {
+              editAll(context, ride.parentRide);
+            }
+            else if (ride.recurring) {
+              editAll(context, ride);
+            }
+            else {
+              throw Exception('Editing all repeating rides failed for ride ${ride.id} with recurring=${ride.recurring} and parentRide=${ride.parentRide}');
+            }
           },
         ));
 
@@ -380,7 +393,7 @@ class RideActions extends StatelessWidget {
                     padding: EdgeInsets.only(top: 18),
                     child: RaisedButton.icon(
                         onPressed: () async {
-                          if (ride.parentRide != null) {
+                          if (ride.parentRide != null || ride.recurring) {
                             showEditDialog();
                           } else {
                             editSingle(context, ride);

--- a/lib/pages/RidePage.dart
+++ b/lib/pages/RidePage.dart
@@ -260,38 +260,23 @@ class RideActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    RideFlowProvider createRideProvider =
-    Provider.of<RideFlowProvider>(context);
+    RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
 
     void editSingle(BuildContext context, Ride ride) {
-      createRideProvider.setLocControllers(
-          ride.startLocation, ride.endLocation);
-      createRideProvider.setPickupTimeCtrl(
-          TimeOfDay.fromDateTime(ride.startTime).format(context));
-      createRideProvider.setDropoffTimeCtrl(
-          TimeOfDay.fromDateTime(ride.endTime).format(context));
-      createRideProvider.setStartDateCtrl(ride.startTime);
-      createRideProvider.setEditing(true);
+      print(ride.id);
+      rideFlowProvider.setEditing(context, ride);
       Navigator.push(
           context,
           MaterialPageRoute(
-              builder: (context) => RequestRideLoc(ride: ride.copy())));
+              builder: (context) => RequestRideLoc()));
     }
 
     void editAll(BuildContext context, Ride parentRide) {
-      createRideProvider.setLocControllers(
-          parentRide.startLocation, parentRide.endLocation);
-      createRideProvider.setPickupTimeCtrl(
-          TimeOfDay.fromDateTime(parentRide.startTime).format(context));
-      createRideProvider.setDropoffTimeCtrl(
-          TimeOfDay.fromDateTime(parentRide.endTime).format(context));
-      createRideProvider.setStartDateCtrl(parentRide.startTime);
-      createRideProvider.setEndDateCtrl(parentRide.endDate);
-      createRideProvider.setEditing(true);
+      rideFlowProvider.setEditing(context, parentRide);
       Navigator.push(
           context,
           MaterialPageRoute(
-              builder: (context) => RequestRideLoc(ride: parentRide.copy())));
+              builder: (context) => RequestRideLoc()));
     }
 
     Widget editSingleButton(BuildContext context) => ButtonTheme(
@@ -307,18 +292,11 @@ class RideActions extends StatelessWidget {
           child: Text('Edit This Ride',
               style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
           onPressed: () {
-            createRideProvider.setLocControllers(
-                ride.startLocation, ride.endLocation);
-            createRideProvider.setPickupTimeCtrl(
-                TimeOfDay.fromDateTime(ride.startTime).format(context));
-            createRideProvider.setDropoffTimeCtrl(
-                TimeOfDay.fromDateTime(ride.endTime).format(context));
-            createRideProvider.setStartDateCtrl(ride.startTime);
-            createRideProvider.setEditing(true);
+            rideFlowProvider.setEditing(context, ride);
             Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (context) => RequestRideLoc(ride: ride.copy())));
+                    builder: (context) => RequestRideLoc()));
           },
         ));
 

--- a/lib/pages/ride-flow/FlowWidgets.dart
+++ b/lib/pages/ride-flow/FlowWidgets.dart
@@ -16,8 +16,7 @@ class FlowCancel extends StatelessWidget {
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
 
     void onTap() {
-      rideFlowProvider.clearControllers();
-      rideFlowProvider.setError(false);
+      rideFlowProvider.clear();
       Navigator.popUntil(context, ModalRoute.withName('/'));
     }
 

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -13,9 +13,8 @@ import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
 
 
 class RequestRideLoc extends StatefulWidget {
-  final Ride ride;
 
-  RequestRideLoc({Key key, @required this.ride}) : super(key: key);
+  RequestRideLoc({Key key}) : super(key: key);
 
   @override
   _RequestRideLocState createState() => _RequestRideLocState();
@@ -28,8 +27,8 @@ class _RequestRideLocState extends State<RequestRideLoc> {
   Widget build(context) {
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
-    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
-    TextEditingController toCtrl = rideFlowProvider.toCtrl;
+    TextEditingController fromCtrl = rideFlowProvider.startLocCtrl;
+    TextEditingController toCtrl = rideFlowProvider.endLocCtrl;
 
     double buttonHeight = 48;
     double buttonVerticalPadding = 16;
@@ -83,7 +82,6 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                             children: <Widget>[
                               LocationInput(
                                 label: 'From',
-                                ride: widget.ride,
                                 finished: rideFlowProvider.locationsFinished(),
                                 isToLocation: false,
                               ),
@@ -103,7 +101,6 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                               SizedBox(height: 30.0),
                               LocationInput(
                                 label: 'To',
-                                ride: widget.ride,
                                 finished: rideFlowProvider.locationsFinished(),
                                 isToLocation: true,
                               ),
@@ -147,11 +144,9 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                         onPressed: () {
                           if (_formKey.currentState.validate()) {
                             Navigator.push(context, MaterialPageRoute(
-                                builder: (context) => rideFlowProvider.editing ? RequestRideDateTime(ride: widget.ride) : RequestRideType(ride: widget.ride)
+                                builder: (context) => rideFlowProvider.editing ? RequestRideDateTime() : RequestRideType()
                             )
                             );
-                            widget.ride.startLocation = fromCtrl.text;
-                            widget.ride.endLocation = toCtrl.text;
                           }
                           else {
                             SemanticsService.announce('Error, please check your locations', TextDirection.ltr);
@@ -199,8 +194,8 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
   @override
   Widget build(BuildContext context) {
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
-    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
-    TextEditingController toCtrl = rideFlowProvider.toCtrl;
+    TextEditingController fromCtrl = rideFlowProvider.startLocCtrl;
+    TextEditingController toCtrl = rideFlowProvider.endLocCtrl;
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
 
     String input = widget.isToLocation ? toCtrl.text : fromCtrl.text;
@@ -348,8 +343,8 @@ class LocationInput extends StatelessWidget {
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context);
     RideFlowProvider rideFlowProvider = Provider.of<RideFlowProvider>(context);
-    TextEditingController fromCtrl = rideFlowProvider.fromCtrl;
-    TextEditingController toCtrl = rideFlowProvider.toCtrl;
+    TextEditingController fromCtrl = rideFlowProvider.startLocCtrl;
+    TextEditingController toCtrl = rideFlowProvider.endLocCtrl;
 
     List<String> initSuggestions;
     if (isToLocation && toCtrl.text != null && toCtrl.text != '') {
@@ -392,7 +387,7 @@ class LocationInput extends StatelessWidget {
                 ride: ride,
                 label: label,
                 isToLocation: isToLocation,
-                page: RequestRideLoc(ride: ride),
+                page: RequestRideLoc(),
                 initSuggestions: initSuggestions
             ),
           )

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -144,7 +144,7 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                         onPressed: () {
                           if (_formKey.currentState.validate()) {
                             Navigator.push(context, MaterialPageRoute(
-                                builder: (context) => rideFlowProvider.editing ? RequestRideDateTime() : RequestRideType()
+                                builder: (context) => (rideFlowProvider.creating()) ? RequestRideType() : RequestRideDateTime()
                             )
                             );
                           }

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 import 'dart:math';
-
-import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Review_Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/ToggleButton.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
@@ -9,7 +7,6 @@ import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
 import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -225,21 +225,21 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       );
     }
 
-    String validateStartDate() {
+    String validateStartDate(bool checkEmpty) {
       String error;
       if (rideFlowProvider.startDate != null) {
         if (rideFlowProvider.recurring && rideFlowProvider.endDate != null && rideFlowProvider.startDate.isAfter(rideFlowProvider.endDate)) {
           error = 'Start date must be before end date';
         }
       }
-      else {
+      else if (checkEmpty) {
         error = 'Please enter the ' + (rideFlowProvider.recurring ? 'start date' : 'date');
       }
       startDateError = error;
       return error;
     }
 
-    String validateEndDate() {
+    String validateEndDate(bool checkEmpty) {
       String error;
       if (rideFlowProvider.recurring) {
         if (rideFlowProvider.endDate != null) {
@@ -248,7 +248,7 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
             error = 'End date must be after start date';
           }
         }
-        else {
+        else if (checkEmpty) {
           error = 'Please enter the end date';
         }
       }
@@ -260,8 +260,8 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       selectDate(context, rideFlowProvider.startDate == null ? firstPossibleRideDate() : rideFlowProvider.startDate, (DateTime selection) {
         rideFlowProvider.setStartDate(selection);
         setState(() {
-          startDateError = validateStartDate();
-          endDateError = validateEndDate();
+          startDateError = validateStartDate(true);
+          endDateError = validateEndDate(false);
         });
       });
     }
@@ -270,34 +270,34 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       selectDate(context, rideFlowProvider.endDate == null ? firstPossibleRideDate() : rideFlowProvider.endDate, (DateTime selection) {
         rideFlowProvider.setEndDate(selection);
         setState(() {
-          startDateError = validateStartDate();
-          endDateError = validateEndDate();
+          startDateError = validateStartDate(false);
+          endDateError = validateEndDate(true);
         });
       });
     }
 
-    String validateStartTime() {
+    String validateStartTime(bool checkEmpty) {
       String error;
       if (rideFlowProvider.pickUpTime != null) {
         if (rideFlowProvider.dropOffTime != null && timeToDouble(rideFlowProvider.pickUpTime) >= timeToDouble(rideFlowProvider.dropOffTime)) {
           error = 'Start time must be before end time';
         }
       }
-      else {
+      else if (checkEmpty) {
         error = 'Please enter your pickup time';
       }
       startTimeError = error;
       return error;
     }
 
-    String validateEndTime() {
+    String validateEndTime(bool checkEmpty) {
       String error;
       if (rideFlowProvider.dropOffTime != null ) {
         if (rideFlowProvider.pickUpTime != null && timeToDouble(rideFlowProvider.pickUpTime) >= timeToDouble(rideFlowProvider.dropOffTime)) {
           error = 'End time must be after start time';
         }
       }
-      else {
+      else if (checkEmpty) {
         error = 'Please enter your drop-off time';
       }
       endTimeError = error;
@@ -308,8 +308,8 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       selectTime(context, rideFlowProvider.pickUpTime == null ? TimeOfDay.now() : rideFlowProvider.pickUpTime, (TimeOfDay selection) {
         rideFlowProvider.setPickUpTime(selection, context);
         setState(() {
-          startTimeError = validateStartTime();
-          endTimeError = validateEndTime();
+          startTimeError = validateStartTime(true);
+          endTimeError = validateEndTime(false);
         });
       });
     }
@@ -318,8 +318,8 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
       selectTime(context, rideFlowProvider.dropOffTime == null ? TimeOfDay.now() : rideFlowProvider.dropOffTime, (selection) {
         rideFlowProvider.setDropOffTime(selection, context);
         setState(() {
-          startTimeError = validateStartTime();
-          endTimeError = validateEndTime();
+          startTimeError = validateStartTime(false);
+          endTimeError = validateEndTime(true);
         });
       });
     }
@@ -353,10 +353,10 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
     );
 
     bool allValid() {
-      bool validStartTime = validateStartTime() == null;
-      bool validEndTime = validateEndTime() == null;
-      bool validStartDate = validateStartDate() == null;
-      bool validEndDate = validateEndDate() == null;
+      bool validStartTime = validateStartTime(true) == null;
+      bool validEndTime = validateEndTime(true) == null;
+      bool validStartDate = validateStartDate(true) == null;
+      bool validEndDate = validateEndDate(true) == null;
       return validStartDate && validEndDate && validStartTime && validEndTime;
     }
     double buttonsHeight = 48;

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -1,13 +1,11 @@
 import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/pages/ride-flow/Ride_Confirmation.dart';
 import 'package:carriage_rider/providers/RideFlowProvider.dart';
-import 'package:carriage_rider/providers/LocationsProvider.dart';
 import 'package:carriage_rider/widgets/Buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:loading_overlay/loading_overlay.dart';
 import 'package:provider/provider.dart';
-import 'package:carriage_rider/utils/app_config.dart';
 import 'package:carriage_rider/pages/ride-flow/FlowWidgets.dart';
 import 'package:carriage_rider/utils/CarriageTheme.dart';
 

--- a/lib/pages/ride-flow/Review_Ride.dart
+++ b/lib/pages/ride-flow/Review_Ride.dart
@@ -59,7 +59,7 @@ class _ReviewRideState extends State<ReviewRide> {
                           colorTwo: Colors.green,
                           colorThree: Colors.black),
                       SizedBox(height: 30),
-                      ride.buildSummary(context),
+                      ride.buildSummary(context, (rideFlowProvider.creating() && rideFlowProvider.recurring) || rideFlowProvider.editingAll()),
                     ],
                   ),
                 ),
@@ -84,7 +84,7 @@ class _ReviewRideState extends State<ReviewRide> {
                         SizedBox(width: 24),
                         Expanded(
                           child: CButton(
-                            text: rideFlowProvider.editing ? 'Update Request' : 'Send Request',
+                            text: rideFlowProvider.creating() ? 'Send Request' : 'Update Request',
                             height: buttonsHeight,
                             onPressed: () async {
                               setState(() {

--- a/lib/pages/ride-flow/Ride_Confirmation.dart
+++ b/lib/pages/ride-flow/Ride_Confirmation.dart
@@ -25,7 +25,7 @@ class _RideConfirmationState extends State<RideConfirmation> {
           SizedBox(height: MediaQuery.of(context).size.height * 0.2),
           Padding(
             padding: EdgeInsets.symmetric(horizontal: 40),
-            child: ExcludeSemantics(child: Image(image: AssetImage(rideFlowProvider.editing ? 'assets/images/changesInProgress.png' : 'assets/images/RequestInProgress.png'))),
+            child: ExcludeSemantics(child: Image(image: AssetImage(rideFlowProvider.creating() ? 'assets/images/RequestInProgress.png' : 'assets/images/changesInProgress.png'))),
           ),
           SizedBox(height: 36),
           Padding(
@@ -35,7 +35,7 @@ class _RideConfirmationState extends State<RideConfirmation> {
               children: <Widget>[
                 Expanded(
                   child: Text(
-                      rideFlowProvider.editing ? 'Your changes are in progress!' : 'Your request is in progress!',
+                      rideFlowProvider.creating() ? 'Your request is in progress!' : 'Your changes are in progress!',
                       textAlign: TextAlign.center,
                       style: CarriageTheme.title3
                   ),

--- a/lib/providers/RideFlowProvider.dart
+++ b/lib/providers/RideFlowProvider.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
-import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
 import 'dart:io';
 import 'package:intl/intl.dart';

--- a/lib/providers/RideFlowProvider.dart
+++ b/lib/providers/RideFlowProvider.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
+import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
 import 'dart:io';
 import 'package:intl/intl.dart';
@@ -206,10 +207,6 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to edit instance of recurring ride: ${response.body}');
       return false;
     }
-    await locationsProvider.fetchLocations(context, config, authProvider);
-    RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
-    await ridesProvider.fetchAllRides(config, authProvider);
-    notifyListeners();
     return true;
   }
 
@@ -242,9 +239,6 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to update ride: ${response.body}');
       return false;
     }
-    await locationsProvider.fetchLocations(context, config, authProvider);
-    RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
-    await ridesProvider.fetchAllRides(config, authProvider);
     notifyListeners();
     return true;
   }
@@ -258,9 +252,11 @@ class RideFlowProvider with ChangeNotifier {
     AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
+    RiderProvider riderProvider = Provider.of<RiderProvider>(context, listen: false);
 
     String token = await authProvider.secureStorage.read(key: 'token');
     Map<String, dynamic> request = <String, dynamic>{
+      'rider': riderProvider.info.id,
       'startLocation': assembleStartLocation(locationsProvider),
       'endLocation': assembleEndLocation(locationsProvider),
       'startTime': assembleStartTimeString(),
@@ -284,10 +280,6 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to create ride: ${response.body}');
       return false;
     }
-    await locationsProvider.fetchLocations(context, config, authProvider);
-    RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
-    await ridesProvider.fetchAllRides(config, authProvider);
-    notifyListeners();
     return true;
   }
 
@@ -309,6 +301,14 @@ class RideFlowProvider with ChangeNotifier {
     else {
       successful = await createRide(context);
     }
+    AppConfig config = AppConfig.of(context);
+    AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
+    await locationsProvider.fetchLocations(context, config, authProvider);
+    RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
+    await ridesProvider.fetchAllRides(config, authProvider);
+    notifyListeners();
+
     return successful;
   }
 }

--- a/lib/providers/RideFlowProvider.dart
+++ b/lib/providers/RideFlowProvider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:carriage_rider/models/Ride.dart';
 import 'package:carriage_rider/providers/LocationsProvider.dart';
 import 'package:carriage_rider/providers/RiderProvider.dart';
 import 'package:carriage_rider/providers/RidesProvider.dart';
@@ -13,56 +14,124 @@ import 'package:provider/provider.dart';
 /// Manage the state of rides with ChangeNotifier.
 class RideFlowProvider with ChangeNotifier {
   bool editing;
-  TextEditingController fromCtrl = TextEditingController();
-  TextEditingController toCtrl = TextEditingController();
+  Ride origRide;
+
+  TextEditingController startLocCtrl = TextEditingController();
+  TextEditingController endLocCtrl = TextEditingController();
   TextEditingController startDateCtrl = TextEditingController();
   TextEditingController endDateCtrl = TextEditingController();
-  TextEditingController pickUpCtrl = TextEditingController();
-  TextEditingController dropOffCtrl = TextEditingController();
+  TextEditingController pickUpTimeCtrl = TextEditingController();
+  TextEditingController dropOffTimeCtrl = TextEditingController();
+
+  bool recurring;
+  DateTime startDate;
+  DateTime endDate;
+  TimeOfDay pickUpTime;
+  TimeOfDay dropOffTime;
+  List<bool> repeatDaysSelected = List.filled(5, false);
 
   bool requestHadError = false;
 
-  bool locationsFinished() => fromCtrl.text != null && fromCtrl.text != '' && toCtrl.text != null && toCtrl.text != '';
-  bool locationsEmpty() => (fromCtrl.text == null || fromCtrl.text == '') && (toCtrl.text == null || toCtrl.text == '');
+  bool locationsFinished() => startLocCtrl.text != null && startLocCtrl.text != '' && endLocCtrl.text != null && endLocCtrl.text != '';
+  bool locationsEmpty() => (startLocCtrl.text == null || startLocCtrl.text == '') && (endLocCtrl.text == null || endLocCtrl.text == '');
 
-  void setEditing(bool isEditing) {
-    editing = isEditing;
+  void clear() {
+    startLocCtrl.clear();
+    endLocCtrl.clear();
+    startDateCtrl.clear();
+    endDateCtrl.clear();
+    pickUpTimeCtrl.clear();
+    dropOffTimeCtrl.clear();
+    startDate = null;
+    endDate = null;
+    pickUpTime = null;
+    dropOffTime = null;
+    repeatDaysSelected = List.filled(5, false);
+    requestHadError = false;
     notifyListeners();
   }
 
-  void setStartDateCtrl(DateTime date) {
+  void initFromRide(BuildContext context, Ride ride) {
+    setLocControllers(ride.startLocation, ride.endLocation);
+    setPickUpTime(TimeOfDay.fromDateTime(ride.startTime), context);
+    setDropOffTime(TimeOfDay.fromDateTime(ride.endTime), context);
+    setStartDate(ride.startTime);
+    if (ride.recurring) {
+      setRecurring(true);
+      setEndDate(ride.endDate);
+      repeatDaysSelected = List.filled(5, false);
+      ride.recurringDays.forEach((day) {
+        repeatDaysSelected[day-1] = true;
+      });
+    }
+    else {
+      setRecurring(false);
+    }
+    notifyListeners();
+  }
+
+  Ride assembleRide(BuildContext context) {
+    Ride ride = Ride(
+      startLocation: startLocCtrl.text,
+      endLocation: endLocCtrl.text,
+      startTime: assembleStartTime(),
+      endTime: assembleEndTime(),
+    );
+    if (recurring) {
+      ride.recurring = true;
+      ride.endDate = endDate;
+      ride.recurringDays = assembleRecurringDays();
+    }
+    else {
+      ride.recurring = false;
+    }
+    return ride;
+  }
+
+  void setCreating() {
+    editing = false;
+    notifyListeners();
+  }
+
+  void setEditing(BuildContext context, Ride ride) {
+    editing = true;
+    origRide = ride;
+    initFromRide(context, ride);
+    notifyListeners();
+  }
+
+  void setRecurring(bool isRecurring) {
+    recurring = isRecurring;
+    notifyListeners();
+  }
+
+  void setStartDate(DateTime date) {
+    startDate = date;
     startDateCtrl.text = DateFormat('yMd').format(date);
     notifyListeners();
   }
 
-  void setEndDateCtrl(DateTime date) {
+  void setEndDate(DateTime date) {
+    endDate = date;
     endDateCtrl.text = DateFormat('yMd').format(date);
     notifyListeners();
   }
 
-  void setPickupTimeCtrl(String time) {
-    pickUpCtrl.text = time;
+  void setPickUpTime(TimeOfDay time, BuildContext context) {
+    pickUpTime = time;
+    pickUpTimeCtrl.text = time.format(context);
     notifyListeners();
   }
 
-  void setDropoffTimeCtrl(String time) {
-    dropOffCtrl.text = time;
+  void setDropOffTime(TimeOfDay time, BuildContext context) {
+    dropOffTime = time;
+    dropOffTimeCtrl.text = time.format(context);
     notifyListeners();
   }
 
   void setLocControllers(String fromLocation, String toLocation) {
-    fromCtrl.text = fromLocation;
-    toCtrl.text = toLocation;
-    notifyListeners();
-  }
-
-  void clearControllers() {
-    fromCtrl.clear();
-    toCtrl.clear();
-    startDateCtrl.clear();
-    endDateCtrl.clear();
-    pickUpCtrl.clear();
-    dropOffCtrl.clear();
+    startLocCtrl.text = fromLocation;
+    endLocCtrl.text = toLocation;
     notifyListeners();
   }
 
@@ -71,30 +140,64 @@ class RideFlowProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void setRepeatDays(List<bool> selected) {
+    repeatDaysSelected = selected;
+    notifyListeners();
+  }
+
+  void toggleRepeatDays(int index) {
+    repeatDaysSelected[index] = !repeatDaysSelected[index];
+    notifyListeners();
+  }
+
+  DateTime assembleStartTime() => DateTime(startDate.year, startDate.month, startDate.day, pickUpTime.hour, pickUpTime.minute);
+  String assembleStartTimeString() => assembleStartTime().toUtc().toIso8601String();
+  DateTime assembleEndTime() => DateTime(startDate.year, startDate.month, startDate.day, dropOffTime.hour, dropOffTime.minute);
+  String assembleEndTimeString() => assembleEndTime().toUtc().toIso8601String();
+
+  String assembleStartLocation(LocationsProvider locationsProvider) {
+    String input = startLocCtrl.text;
+    if (locationsProvider.isPreset(input)) {
+      return locationsProvider.locationByName(input).id;
+    }
+    return input;
+  }
+
+  String assembleEndLocation(LocationsProvider locationsProvider) {
+    String input = endLocCtrl.text;
+    if (locationsProvider.isPreset(input)) {
+      return locationsProvider.locationByName(input).id;
+    }
+    return input;
+  }
+
+  List<int> assembleRecurringDays() {
+    List<int> recurringDays = [];
+    for (int i = 0; i < repeatDaysSelected.length; i++) {
+      if (repeatDaysSelected[i]) {
+        recurringDays.add(i+1);
+      }
+    }
+    return recurringDays;
+  }
+
   Future<bool> updateRecurringRide(
-      AppConfig config,
       BuildContext context,
-      String parentRideID,
-      DateTime origDate,
-      String startLocation,
-      String endLocation,
-      DateTime startTime,
-      DateTime endTime,
-      bool recurring,
-      {DateTime endDate,
-        List<int> recurringDays}) async {
+      Ride origRide) async {
+    AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
     String token = await authProvider.secureStorage.read(key: 'token');
     Map<String, dynamic> request = <String, dynamic>{
-      'id': parentRideID,
+      'id': origRide.parentRide.id,
       'deleteOnly': false,
-      'origDate': DateFormat('yyyy-MM-dd').format(origDate),
-      'startLocation': startLocation,
-      'endLocation': endLocation,
-      'startTime': startTime.toUtc().toIso8601String(),
-      'endTime': endTime.toUtc().toIso8601String(),
+      'origDate': DateFormat('yyyy-MM-dd').format(origRide.origDate),
+      'startLocation': assembleStartLocation(locationsProvider),
+      'endLocation': assembleEndLocation(locationsProvider),
+      'startTime': assembleStartTimeString(),
+      'endTime': assembleEndTimeString()
     };
-    final response = await http.put('${config.baseUrl}/rides/$parentRideID/edits',
+    final response = await http.put('${config.baseUrl}/rides/${origRide.parentRide.id}/edits',
         headers: <String, String>{
           'Content-Type': 'application/json; charset=UTF-8',
           HttpHeaders.authorizationHeader: 'Bearer $token'
@@ -104,7 +207,6 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to edit instance of recurring ride: ${response.body}');
       return false;
     }
-    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
     await locationsProvider.fetchLocations(context, config, authProvider);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
     await ridesProvider.fetchAllRides(config, authProvider);
@@ -112,33 +214,26 @@ class RideFlowProvider with ChangeNotifier {
     return true;
   }
 
-  Future<bool> updateRide(
-      AppConfig config,
-      BuildContext context,
-      String rideID,
-      String startLocation,
-      String endLocation,
-      DateTime startTime,
-      DateTime endTime,
-      bool recurring,
-      {DateTime endDate,
-        List<int> recurringDays}) async {
+  Future<bool> updateRide(BuildContext context) async {
+    AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
+
     String token = await authProvider.secureStorage.read(key: 'token');
     Map<String, dynamic> request = <String, dynamic>{
-      'startLocation': startLocation,
-      'endLocation': endLocation,
-      'startTime': startTime.toUtc().toIso8601String(),
-      'endTime': endTime.toUtc().toIso8601String(),
+      'startLocation': assembleStartLocation(locationsProvider),
+      'endLocation': assembleEndLocation(locationsProvider),
+      'startTime': assembleStartTimeString(),
+      'endTime': assembleEndTimeString()
     };
     if (recurring) {
       request['recurring'] = true;
       request['endDate'] = DateTime.parse(DateFormat('y-MM-dd').format(endDate))
           .toIso8601String()
           .substring(0, 10);
-      request['recurringDays'] = recurringDays;
+      request['recurringDays'] = assembleRecurringDays();
     }
-    final response = await http.put('${config.baseUrl}/rides/$rideID',
+    final response = await http.put('${config.baseUrl}/rides/${origRide.id}',
         headers: <String, String>{
           'Content-Type': 'application/json; charset=UTF-8',
           HttpHeaders.authorizationHeader: 'Bearer $token'
@@ -148,7 +243,6 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to update ride: ${response.body}');
       return false;
     }
-    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
     await locationsProvider.fetchLocations(context, config, authProvider);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
     await ridesProvider.fetchAllRides(config, authProvider);
@@ -161,32 +255,24 @@ class RideFlowProvider with ChangeNotifier {
   /// just the location name if it is a new location (not in backend yet) and
   /// a DateTime string converted into UTC time zone for [startTime] and [endTime].
   /// Returns whether the request was successful or not.
-  Future<bool> createRide(
-      AppConfig config,
-      BuildContext context,
-      String startLocation,
-      String endLocation,
-      DateTime startTime,
-      DateTime endTime,
-      bool recurring,
-      {DateTime endDate,
-        List<int> recurringDays}) async {
+  Future<bool> createRide(BuildContext context) async {
+    AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
-    RiderProvider riderProvider = Provider.of<RiderProvider>(context, listen: false);
+    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
+
     String token = await authProvider.secureStorage.read(key: 'token');
     Map<String, dynamic> request = <String, dynamic>{
-      'rider': riderProvider.info.id,
-      'startLocation': startLocation,
-      'endLocation': endLocation,
-      'startTime': startTime.toUtc().toIso8601String(),
-      'endTime': endTime.toUtc().toIso8601String(),
+      'startLocation': assembleStartLocation(locationsProvider),
+      'endLocation': assembleEndLocation(locationsProvider),
+      'startTime': assembleStartTimeString(),
+      'endTime': assembleEndTimeString()
     };
     if (recurring) {
       request['recurring'] = true;
       request['endDate'] = DateTime.parse(DateFormat('y-MM-dd').format(endDate))
           .toIso8601String()
           .substring(0, 10);
-      request['recurringDays'] = recurringDays;
+      request['recurringDays'] = assembleRecurringDays();
     }
 
     final response = await http.post('${config.baseUrl}/rides',
@@ -199,11 +285,31 @@ class RideFlowProvider with ChangeNotifier {
       print('Failed to create ride: ${response.body}');
       return false;
     }
-    LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
     await locationsProvider.fetchLocations(context, config, authProvider);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
     await ridesProvider.fetchAllRides(config, authProvider);
     notifyListeners();
     return true;
+  }
+
+  Future<bool> request(BuildContext context) async {
+    bool successful;
+    if (editing) {
+      // update fake instance for recurring ride
+      if (origRide.parentRide != null) {
+        successful = await updateRecurringRide(
+          context,
+          origRide
+        );
+      }
+      // update real instance
+      else {
+        successful = await updateRide(context);
+      }
+    }
+    else {
+      successful = await createRide(context);
+    }
+    return successful;
   }
 }

--- a/lib/providers/RidesProvider.dart
+++ b/lib/providers/RidesProvider.dart
@@ -163,16 +163,16 @@ class RidesProvider with ChangeNotifier {
     fetchAllRides(config, authProvider);
   }
 
-  Future<void> cancelRepeatingRideOccurrence(BuildContext context, Ride ride) async {
+  Future<void> cancelRepeatingRideOccurrence(BuildContext context, Ride origRide) async {
     AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
     String token = await authProvider.secureStorage.read(key: 'token');
     Map<String, dynamic> request = <String, dynamic>{
-      'id': ride.id,
+      'id': origRide.id,
       'deleteOnly': true,
-      'origDate': DateFormat('yyyy-MM-dd').format(ride.origDate),
+      'origDate': DateFormat('yyyy-MM-dd').format(origRide.origDate),
     };
-    final response = await http.put('${config.baseUrl}/rides/${ride.parentRide.id}/edits',
+    final response = await http.put('${config.baseUrl}/rides/${origRide.parentRide.id}/edits',
         headers: <String, String>{
           'Content-Type': 'application/json; charset=UTF-8',
           HttpHeaders.authorizationHeader: 'Bearer $token'

--- a/lib/providers/RidesProvider.dart
+++ b/lib/providers/RidesProvider.dart
@@ -13,7 +13,7 @@ import 'package:provider/provider.dart';
 class RidesProvider with ChangeNotifier {
   Ride currentRide;
   List<Ride> pastRides;
-  List<Ride> upcomingSingleRides;
+  List<Ride> existingUpcomingRides;
   List<Ride> _parentRecurringRides;
   List<Ride> upcomingRides;
 
@@ -30,16 +30,16 @@ class RidesProvider with ChangeNotifier {
 
   bool hasData() {
     return pastRides != null &&
-        upcomingSingleRides != null &&
+        existingUpcomingRides != null &&
         _parentRecurringRides != null &&
         upcomingRides != null;
   }
 
   _generateUpcomingRides() {
     List<Ride> recurringRides =
-    RecurringRidesGenerator(_parentRecurringRides, upcomingSingleRides)
+    RecurringRidesGenerator(_parentRecurringRides, existingUpcomingRides)
         .generateRecurringRides();
-    upcomingRides = upcomingSingleRides;
+    upcomingRides = existingUpcomingRides;
     upcomingRides.addAll(recurringRides);
     upcomingRides.sort((a, b) => a.startTime.compareTo(b.startTime));
   }
@@ -82,18 +82,16 @@ class RidesProvider with ChangeNotifier {
   /// Fetches a list of upcoming rides from the backend by using the baseUrl of [config] and rider id from [authProvider].
   /// Upcoming rides are sorted from closest in time to farthest forward in time,
   /// so upcoming rides has the soonest ride first.
-  Future<void> _fetchUpcomingSingleRides(AppConfig config,
+  Future<void> _fetchExistingUpcomingRides(AppConfig config,
       AuthProvider authProvider) async {
     String token = await authProvider.secureStorage.read(key: 'token');
     final response = await http.get(
         '${config.baseUrl}/rides?status=not_started&rider=${authProvider.id}',
         headers: {HttpHeaders.authorizationHeader: 'Bearer $token'});
     if (response.statusCode == 200) {
-      List<Ride> rides = _ridesFromJson(response.body)
-          .where((ride) => !ride.recurring)
-          .toList();
+      List<Ride> rides = _ridesFromJson(response.body).toList();
       rides.sort((a, b) => a.startTime.compareTo(b.startTime));
-      upcomingSingleRides = rides;
+      existingUpcomingRides = rides;
     }
   }
 
@@ -138,11 +136,11 @@ class RidesProvider with ChangeNotifier {
       AuthProvider authProvider) async {
     await _fetchCurrentRide(config, authProvider);
     await _fetchPastRides(config, authProvider);
-    await _fetchUpcomingSingleRides(config, authProvider);
+    await _fetchExistingUpcomingRides(config, authProvider);
     await _fetchParentRecurringRides(config, authProvider);
     _generateUpcomingRides();
     if (currentRide != null) {
-      upcomingSingleRides.removeWhere((ride) => ride.id == currentRide.id);
+      existingUpcomingRides.removeWhere((ride) => ride.id == currentRide.id);
     }
     notifyListeners();
   }
@@ -170,16 +168,16 @@ class RidesProvider with ChangeNotifier {
     Map<String, dynamic> request = <String, dynamic>{
       'id': origRide.id,
       'deleteOnly': true,
-      'origDate': DateFormat('yyyy-MM-dd').format(origRide.origDate),
+      'origDate': DateFormat('yyyy-MM-dd').format(origRide.origDate != null ? origRide.origDate : origRide.startTime),
     };
-    final response = await http.put('${config.baseUrl}/rides/${origRide.parentRide.id}/edits',
+    final response = await http.put('${config.baseUrl}/rides/${origRide.parentRide != null ? origRide.parentRide.id : origRide.id}/edits',
         headers: <String, String>{
           'Content-Type': 'application/json; charset=UTF-8',
           HttpHeaders.authorizationHeader: 'Bearer $token'
         },
         body: jsonEncode(request));
     if (response.statusCode != 200) {
-      throw Exception('Failed to delete instance of recurring ride: ${response.body}');
+      throw Exception('Failed to cancel instance of recurring ride: ${response.body}');
     }
     fetchAllRides(config, authProvider);
   }

--- a/lib/utils/RecurringRidesGenerator.dart
+++ b/lib/utils/RecurringRidesGenerator.dart
@@ -86,9 +86,9 @@ class RecurringRidesGenerator {
         // create the new ride and keep track of its parent to help with editing
         Ride rideInstance = Ride(
             parentRide: originalRide,
+            origDate: rideStart,
             status: RideStatus.NOT_STARTED,
             type: 'unscheduled',
-            origDate: rideStart,
             startLocation: originalRide.startLocation,
             startAddress: originalRide.startAddress,
             endLocation: originalRide.endLocation,

--- a/lib/utils/RecurringRidesGenerator.dart
+++ b/lib/utils/RecurringRidesGenerator.dart
@@ -32,20 +32,11 @@ class RecurringRidesGenerator {
   /// Returns whether the recurring ride from backend [parentRide]'s list of deleted dates contains the start date of [generatedRide],
   /// representing a frontend-generated instance of a repeating ride that does not exist in backend yet.
   ///
-  /// This indicates that the original instance has been deleted so it should NOT be generated in the app.
+  /// This indicates that the original instance has been deleted or edited (original date of ride is added to [parentRide.deleted],
+  /// the edited instance is actually created in backend) so it should NOT be generated in the app.
   bool wasDeleted(Ride generatedRide, Ride parentRide) {
     return parentRide.deleted
         .where((date) => sameDay(date, generatedRide.startTime))
-        .isNotEmpty;
-  }
-
-  /// Returns whether [generatedRide], representing a frontend-generated instance of a repeating ride that does not exist in backend yet,
-  /// was edited and has a real copy in backend.
-  ///
-  /// This indicates that the original instance has been deleted so it should NOT be generated in the app.
-  bool wasEdited(Ride generatedRide, List<Ride> editedRides) {
-    return editedRides
-        .where((ride) => sameDay(ride.startTime, generatedRide.startTime))
         .isNotEmpty;
   }
 
@@ -56,8 +47,7 @@ class RecurringRidesGenerator {
   /// exist in backend yet.
   List<Ride> generateRecurringRides() {
     Map<String, Ride> singleRidesByID = Map();
-    singleRides
-        .forEach((singleRide) => singleRidesByID[singleRide.id] = singleRide);
+    singleRides.forEach((singleRide) => singleRidesByID[singleRide.id] = singleRide);
     List<Ride> generatedRides = [];
 
     for (Ride originalRide in parentRides) {
@@ -101,11 +91,7 @@ class RecurringRidesGenerator {
             (now.isAfter(rideCreationTime) &&
                 sameDay(rideStart, today.add(Duration(days: 1))));
 
-        List<Ride> rideEdits =
-            originalRide.edits.map((id) => singleRidesByID[id]).toList();
-        if (!rideAlreadyExists &&
-            !wasDeleted(rideInstance, originalRide) &&
-            !wasEdited(rideInstance, rideEdits)) {
+        if (!rideAlreadyExists && !wasDeleted(rideInstance, originalRide)) {
           generatedRides.add(rideInstance);
         }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -538,7 +538,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.6"
+    version: "0.2.19-nullsafety.2"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards improving the ride flow state to prevent duplicate data in multiple places (e.g. dates/times in the page state as well as the ride object that was passed between pages, dates/times text controllers in the provider). 
- [x] Removed the Ride object being passed between pages, because this was not getting updated until the proceed button was pressed, which is confusing. RideFlowProvider does have a function for assembling the ride from all of the components, but this is solely used for the summary page, not for the requests, because it can send the individual components of the ride from its state. 
- [x] Pulled all ride creation/editing state into RideFlowProvider, because just keeping state in the pages wouldn't keep the state when the back button is pressed although it would keep the text editing controllers, which caused issues. Just using RideFlowProvider simplifies the request functions and keeps state in one place. 
- [x] Added custom validation logic and rendering for dates/times, because before there was confusing behavior where sometimes times/dates would both update if they were out of order and sometimes only one would update, and the visuals did not match the screen reader text. This was likely due to autovalidate rendering or short-circuit condition evaluation issues that are out of our control.

### Test Plan <!-- Required -->

For each of these, confirmed validation errors worked for invalid inputs and switched between recurring and non-recurring flows to check there are issues with state:
- Create regular rides with preset locations, custom locations, invalid custom locations
- Update regular ride
- Update all instances of recurring ride
- Update single instance of recurring ride

Validation expected behavior:
- When first entering a page, no errors
- No errors about empty fields until button is pressed
- If inputted dates/times are out of order, errors appear automatically even without button press
- Fixing inputted dates/times that are out of order removes the errors automatically even without button press
- Screen reader reads the field info, then "error" + the shown error message

### Notes
This new structure affects efficiency because there is more rebuilding due to notifyListeners being called frequently. Ideally, I believe there should be a wrapper RideFlow widget around the ride flow pages which contains all of the state rather than using a Provider to keep a similar organized structure with less rebuilding, but this may also lead to more complex passing of state. I can attempt a refactor to test whether that seems feasible.