### PR TITLE
Remove addresses for non-custom locations

### DIFF
--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -42,7 +42,6 @@ class MyApp extends StatelessWidget {
           child: ChangeNotifierProvider<LocationsProvider>(
               create: (context) {
                 return LocationsProvider(
-                  context,
                   appConfig,
                   Provider.of<AuthProvider>(context, listen: false),
                   Provider.of<RiderProvider>(context, listen: false),

--- a/lib/models/Ride.dart
+++ b/lib/models/Ride.dart
@@ -13,7 +13,8 @@ enum RideStatus {
   ARRIVED,
   PICKED_UP,
   COMPLETED,
-  NO_SHOW
+  NO_SHOW,
+  CANCELLED
 }
 
 /// Parses [status] representing a ride status into its corresponding enum.
@@ -31,6 +32,8 @@ RideStatus getStatusEnum(String status) {
       return RideStatus.COMPLETED;
     case ('no_show'):
       return RideStatus.NO_SHOW;
+    case ('cancelled'):
+      return RideStatus.CANCELLED;
     default:
       throw Exception('Ride status is invalid');
   }

--- a/lib/pages/RidePage.dart
+++ b/lib/pages/RidePage.dart
@@ -610,6 +610,10 @@ class _TimeLineState extends State<TimeLine> {
     //Widget displaying a custom built card with information about a ride's start location and start time.
     //[isIcon] determines whether the card needs an icon.
     Widget buildLocationsCard(BuildContext context, bool isStart) {
+      LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
+      String location = isStart ? widget.ride.startLocation : widget.ride.endLocation;
+      String address = isStart? widget.ride.startAddress : widget.ride.endAddress;
+
       return Semantics(
         container: true,
         child: Container(
@@ -621,53 +625,62 @@ class _TimeLineState extends State<TimeLine> {
             child: Padding(
               padding: const EdgeInsets.all(16),
               child:
-              Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(isStart ? widget.ride.startLocation : widget.ride.endLocation,
-                                    style: TextStyle(fontSize: 14, color: Color(0xFF1A051D)),
-                                    semanticsLabel: (isStart ? 'Start location: ' + widget.ride.startLocation :
-                                    'End location: ' + widget.ride.endLocation) + '.'
-                                ),
-                                Text(isStart? widget.ride.startAddress : widget.ride.endAddress,
-                                    style: TextStyle(fontSize: 14, color: Color(0xFF1A051D).withOpacity(0.5)),
-                                    semanticsLabel: 'Address: ' + (isStart ? widget.ride.startAddress : widget.ride.endAddress) + '.'
-                                )
-                              ]
-                          ),
-                        ),
-                        widget.hasLocationIcon ? Semantics(
-                          button: true,
-                          container: true,
-                          label: (isStart ? 'Start ' : 'End ') + 'location details',
-                          child: SizedBox(
-                            height: 48,
-                            width: 48,
-                            child: Material(
-                              type: MaterialType.transparency,
-                              child: InkWell(
-                                customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(100)),
-                                child: Icon(Icons.location_on),
-                                onTap: () => displayBottomSheet(context, widget.ride, true),
-                              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: EdgeInsets.only(right: 8),
+                            child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(location,
+                                      style: TextStyle(fontSize: 14, color: Color(0xFF1A051D)),
+                                      semanticsLabel: (isStart ? 'Start location: ' + widget.ride.startLocation :
+                                      'End location: ' + widget.ride.endLocation) + '.'
+                                  ),
+                                  !locationsProvider.isPreset(location) ? Text(address,
+                                      style: TextStyle(fontSize: 14, color: Color(0xFF1A051D).withOpacity(0.5)),
+                                      semanticsLabel: 'Address: ' + address + '.'
+                                  ) : Container()
+                                ]
                             ),
                           ),
-                        )
-                            : Container()
-                      ],
+                          SizedBox(height: 16),
+                          Text(
+                              'Estimated ${isStart ? 'pick up time' : 'drop off time'}: ' +
+                                  DateFormat('jm').format(isStart ? widget.ride.startTime : widget.ride.endTime),
+                              style: TextStyle(fontSize: 13, color: Color(0xFF3F3356))
+                          )
+                        ]
                     ),
-                    SizedBox(height: 16),
-                    Text(
-                        'Estimated ${isStart ? 'pick up time' : 'drop off time'}: ' +
-                            DateFormat('jm').format(isStart ? widget.ride.startTime : widget.ride.endTime),
-                        style: TextStyle(fontSize: 13, color: Color(0xFF3F3356)))
-                  ]),
+                  ),
+                  widget.hasLocationIcon ? Semantics(
+                      button: true,
+                      container: true,
+                      label: (isStart ? 'Start ' : 'End ') + 'location details',
+                      child: Material(
+                        type: MaterialType.transparency,
+                        child: InkWell(
+                          customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(100)),
+                          onTap: () => displayBottomSheet(context, widget.ride, isStart),
+                          child: Container(
+                            width: 48,
+                            height: 48,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(100),
+                              border: Border.all(width: 0.5, color: Colors.black .withOpacity(0.25)
+                              ),
+                            ),
+                            child: Icon(Icons.location_on),
+                          ),
+                        ),
+                      )
+                  ) : Container()
+                ],
+              ),
             )
         ),
       );

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -257,10 +257,10 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          SizedBox(height: 12),
+                          SizedBox(height: 16),
                           Text(name, style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
-                          Text(address, style: TextStyle(color: Colors.grey, fontSize: 12)),
-                          SizedBox(height: 12),
+                          !locationsProvider.isPreset(suggestions[index]) ? Text(address, style: TextStyle(color: Colors.grey, fontSize: 12)) : Container(),
+                          SizedBox(height: 16),
                         ]
                     ),
                   ),

--- a/lib/providers/LocationsProvider.dart
+++ b/lib/providers/LocationsProvider.dart
@@ -6,7 +6,6 @@ import 'package:carriage_rider/providers/AuthProvider.dart';
 import '../utils/app_config.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:provider/provider.dart';
 import 'package:carriage_rider/models/Location.dart';
 
 //Manage the state of locations with ChangeNotifier
@@ -15,13 +14,13 @@ class LocationsProvider with ChangeNotifier {
   List<Location> favLocations;
   Map<String, Location> locationsByName = Map();
   
-  LocationsProvider(BuildContext context, AppConfig config,
+  LocationsProvider(AppConfig config,
       AuthProvider authProvider, RiderProvider riderProvider) {
     void Function() callback;
     callback = () async {
       if (authProvider.isAuthenticated && riderProvider.hasInfo()) {
-        await fetchLocations(context, config, authProvider);
-        await fetchFavoriteLocations(context, config, authProvider);
+        await fetchLocations(config, authProvider);
+        await fetchFavoriteLocations(config, authProvider);
         locations.forEach((loc) => locationsByName[loc.name] = loc);
       }
     };
@@ -40,10 +39,7 @@ class LocationsProvider with ChangeNotifier {
   }
 
   //Fetches all the locations from the backend as a list by using the baseUrl of [config] and id from [authProvider].
-  Future<void> fetchLocations(BuildContext context, AppConfig config,
-      AuthProvider authProvider) async {
-    AuthProvider authProvider =
-    Provider.of<AuthProvider>(context, listen: false);
+  Future<void> fetchLocations( config, AuthProvider authProvider) async {
     String token = await authProvider.secureStorage.read(key: 'token');
     final response = await http.get('${config.baseUrl}/locations',
         headers: {HttpHeaders.authorizationHeader: 'Bearer $token'});
@@ -53,14 +49,12 @@ class LocationsProvider with ChangeNotifier {
       notifyListeners();
     } else {
       await Future.delayed(retryDelay);
-      fetchLocations(context, config, authProvider);
+      fetchLocations(config, authProvider);
     }
   }
 
   //Fetches the rider's favorite locations from the backend.
-  Future<void> fetchFavoriteLocations(BuildContext context, AppConfig config, AuthProvider authProvider) async {
-    AuthProvider authProvider =
-    Provider.of<AuthProvider>(context, listen: false);
+  Future<void> fetchFavoriteLocations(AppConfig config, AuthProvider authProvider) async {
     String token = await authProvider.secureStorage.read(key: 'token');
     final response = await http.get('${config.baseUrl}/riders/${authProvider.id}/favorites',
         headers: {HttpHeaders.authorizationHeader: 'Bearer $token'});
@@ -70,7 +64,7 @@ class LocationsProvider with ChangeNotifier {
       notifyListeners();
     } else {
       await Future.delayed(retryDelay);
-      fetchFavoriteLocations(context, config, authProvider);
+      fetchFavoriteLocations(config, authProvider);
     }
   }
 

--- a/lib/providers/RideFlowProvider.dart
+++ b/lib/providers/RideFlowProvider.dart
@@ -339,7 +339,7 @@ class RideFlowProvider with ChangeNotifier {
     AppConfig config = AppConfig.of(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context, listen: false);
     LocationsProvider locationsProvider = Provider.of<LocationsProvider>(context, listen: false);
-    await locationsProvider.fetchLocations(context, config, authProvider);
+    await locationsProvider.fetchLocations(config, authProvider);
     RidesProvider ridesProvider = Provider.of<RidesProvider>(context, listen: false);
     await ridesProvider.fetchAllRides(config, authProvider);
     notifyListeners();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards removing addresses for non-custom locations

- [x] Removed addresses from ride page
- [x] Removed addresses from ride flow location selection
- [x] Added visible tap area around location icon (just remembered we made this design decision near the end of the semester and I forgot to add it) 
- [x] Fixed ride info which was always showing start location (thought this was fixed, but might've gotten undone in a merge) 
- [x] Temporarily added cancelled ride status to prevent exception from being thrown when fetching rides, should be fixed after backend filters out cancelled rides 

### Test Plan <!-- Required -->

Ride page, both non-custom don't have addresses:
![image](https://user-images.githubusercontent.com/60579411/124845712-44915c00-df65-11eb-9dc6-9f162f31638d.png)

Ride page, both custom have addresses:
![image](https://user-images.githubusercontent.com/60579411/124845693-3c392100-df65-11eb-922b-86e8b73a295c.png)

Ride page, one non-custom and one custom:
![image](https://user-images.githubusercontent.com/60579411/124845673-34797c80-df65-11eb-806d-5b48c8f1d5f4.png)

Remove addresses when selecting non-custom locations: 
![image](https://user-images.githubusercontent.com/60579411/124845658-2d526e80-df65-11eb-8517-4836d17ea8f6.png)

Keep city/state/zip when typing out custom address:
![image](https://user-images.githubusercontent.com/60579411/124845635-21ff4300-df65-11eb-8921-88fecd52e203.png)