### PR TITLE
Screenreader label and semantics fixes

### DIFF
--- a/lib/pages/Contact.dart
+++ b/lib/pages/Contact.dart
@@ -28,14 +28,10 @@ class Contact extends StatelessWidget {
                   SizedBox(height: 8),
                   Padding(
                     padding: EdgeInsets.only(left: 16, right: 16, top: 8),
-                    child:
-                        Semantics(
-                            header: true,
-                            child: Text(
-                                'Before 3:45pm:',
-                                style: CarriageTheme.subHeading
-                            )
-                        ),
+                    child: Semantics(
+                        header: true,
+                        child: Text('Before 3:45pm:',
+                            style: CarriageTheme.subHeading)),
                   ),
                   PhoneNumberRow('6072548293'),
                   ContactRow(Icons.mail, 'culift@cornell.edu',
@@ -43,14 +39,11 @@ class Contact extends StatelessWidget {
                   Divider(),
                   Padding(
                     padding: EdgeInsets.only(left: 16, right: 16, top: 8),
-                    child:
-                        Semantics(
-                          header: true,
-                          child: Text(
-                              'After 3:45pm:',
-                              style: CarriageTheme.subHeading
-                          ),
-                        ),
+                    child: Semantics(
+                      header: true,
+                      child: Text('After 3:45pm:',
+                          style: CarriageTheme.subHeading),
+                    ),
                   ),
                   PhoneNumberRow('6072296010'),
                 ],

--- a/lib/pages/Contact.dart
+++ b/lib/pages/Contact.dart
@@ -29,7 +29,13 @@ class Contact extends StatelessWidget {
                   Padding(
                     padding: EdgeInsets.only(left: 16, right: 16, top: 8),
                     child:
-                        Text('Before 3:45pm:', style: CarriageTheme.subHeading),
+                        Semantics(
+                            header: true,
+                            child: Text(
+                                'Before 3:45pm:',
+                                style: CarriageTheme.subHeading
+                            )
+                        ),
                   ),
                   PhoneNumberRow('6072548293'),
                   ContactRow(Icons.mail, 'culift@cornell.edu',
@@ -38,7 +44,13 @@ class Contact extends StatelessWidget {
                   Padding(
                     padding: EdgeInsets.only(left: 16, right: 16, top: 8),
                     child:
-                        Text('After 3:45pm:', style: CarriageTheme.subHeading),
+                        Semantics(
+                          header: true,
+                          child: Text(
+                              'After 3:45pm:',
+                              style: CarriageTheme.subHeading
+                          ),
+                        ),
                   ),
                   PhoneNumberRow('6072296010'),
                 ],

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -545,16 +545,16 @@ class _HomeState extends State<Home> {
       );
     }
 
-    Widget createDrawerOption(BuildContext context, IconData icon, String text, Widget page) {
+    Widget createDrawerOption(
+        BuildContext context, IconData icon, String text, Widget page) {
       return Semantics(
         button: true,
         child: ListTile(
           leading: Icon(icon, color: Colors.black),
           title: sideBarText(text, Colors.black),
           onTap: () {
-            Navigator.push(context,
-                MaterialPageRoute(builder: (context) => page)
-            );
+            Navigator.push(
+                context, MaterialPageRoute(builder: (context) => page));
           },
         ),
       );
@@ -567,21 +567,17 @@ class _HomeState extends State<Home> {
           child: ListView(
             padding: EdgeInsets.all(5.0),
             children: <Widget>[
-              createDrawerOption(
-                  context, Icons.person, 'Profile', Profile()
+              createDrawerOption(context, Icons.person, 'Profile', Profile()),
+              Divider(
+                color: Colors.grey[500],
               ),
+              createDrawerOption(context, Icons.notifications, 'Notifications',
+                  Notifications()),
               Divider(
                 color: Colors.grey[500],
               ),
               createDrawerOption(
-                  context, Icons.notifications, 'Notifications', Notifications()
-              ),
-              Divider(
-                color: Colors.grey[500],
-              ),
-              createDrawerOption(
-                  context, Icons.help_outline, 'Contact', Contact()
-              ),
+                  context, Icons.help_outline, 'Contact', Contact()),
             ],
           ),
         ),

--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -545,6 +545,21 @@ class _HomeState extends State<Home> {
       );
     }
 
+    Widget createDrawerOption(BuildContext context, IconData icon, String text, Widget page) {
+      return Semantics(
+        button: true,
+        child: ListTile(
+          leading: Icon(icon, color: Colors.black),
+          title: sideBarText(text, Colors.black),
+          onTap: () {
+            Navigator.push(context,
+                MaterialPageRoute(builder: (context) => page)
+            );
+          },
+        ),
+      );
+    }
+
     return Scaffold(
       resizeToAvoidBottomInset: false,
       endDrawer: SafeArea(
@@ -552,38 +567,21 @@ class _HomeState extends State<Home> {
           child: ListView(
             padding: EdgeInsets.all(5.0),
             children: <Widget>[
-              ListTile(
-                leading: Icon(Icons.person, color: Colors.black),
-                title: sideBarText('Profile', Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Profile()));
-                },
+              createDrawerOption(
+                  context, Icons.person, 'Profile', Profile()
               ),
               Divider(
                 color: Colors.grey[500],
               ),
-              ListTile(
-                leading: Icon(Icons.notifications, color: Colors.black),
-                title: sideBarText('Notifications', Colors.black),
-                onTap: () {
-                  Navigator.push(
-                      context,
-                      new MaterialPageRoute(
-                          builder: (context) => Notifications()));
-                },
+              createDrawerOption(
+                  context, Icons.notifications, 'Notifications', Notifications()
               ),
               Divider(
                 color: Colors.grey[500],
               ),
-              ListTile(
-                leading: Icon(Icons.help_outline, color: Colors.black),
-                title: sideBarText('Contact', Colors.black),
-                onTap: () {
-                  Navigator.push(context,
-                      new MaterialPageRoute(builder: (context) => Contact()));
-                },
-              )
+              createDrawerOption(
+                  context, Icons.help_outline, 'Contact', Contact()
+              ),
             ],
           ),
         ),

--- a/lib/pages/Profile.dart
+++ b/lib/pages/Profile.dart
@@ -47,9 +47,12 @@ class Profile extends StatelessWidget {
               child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Padding(
-                padding: EdgeInsets.only(left: 15.0, top: 5.0, bottom: 8.0),
-                child: Text('Your Profile', style: CarriageTheme.largeTitle),
+              Semantics(
+                header: true,
+                child: Padding(
+                  padding: EdgeInsets.only(left: 15.0, top: 5.0, bottom: 8.0),
+                  child: Text('Your Profile', style: CarriageTheme.largeTitle),
+                ),
               ),
               Container(
                   decoration: BoxDecoration(
@@ -164,7 +167,7 @@ class Profile extends StatelessWidget {
                   InfoRow(
                     Icons.phone,
                     riderProvider.info.phoneNumber,
-                    'Phone number',
+                    'Edit phone number',
                     editPage: EditPhoneNumber(riderProvider.info.phoneNumber),
                     readDigits: true,
                   ),
@@ -173,7 +176,7 @@ class Profile extends StatelessWidget {
                     riderProvider.info.firstName +
                         ' ' +
                         riderProvider.info.lastName,
-                    'Name',
+                    'Edit name',
                     editPage: EditName(riderProvider.info.firstName,
                         riderProvider.info.lastName),
                   ),
@@ -373,11 +376,14 @@ class InfoGroup extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Text(title,
-                    style: TextStyle(
-                        fontFamily: 'SFDisplay',
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold)),
+                Semantics(
+                  header: true,
+                  child: Text(title,
+                      style: TextStyle(
+                          fontFamily: 'SFDisplay',
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold)),
+                ),
                 ListView.separated(
                     padding: EdgeInsets.all(0),
                     shrinkWrap: true,

--- a/lib/pages/RidePage.dart
+++ b/lib/pages/RidePage.dart
@@ -60,16 +60,19 @@ class _RidePageState extends State<RidePage> {
                   Padding(
                     padding: const EdgeInsets.only(
                         left: 16, right: 16, bottom: 8, top: 16),
-                    child: Text(
-                        DateFormat('MMM')
-                                .format(widget.ride.startTime)
-                                .toUpperCase() +
-                            ' ' +
-                            ordinal(int.parse(DateFormat('d')
-                                .format(widget.ride.startTime))) +
-                            ' ' +
-                            DateFormat('jm').format(widget.ride.startTime),
-                        style: CarriageTheme.largeTitle),
+                    child: Semantics(
+                      header: true,
+                      child: Text(
+                          DateFormat('MMM')
+                                  .format(widget.ride.startTime)
+                                  .toUpperCase() +
+                              ' ' +
+                              ordinal(int.parse(DateFormat('d')
+                                  .format(widget.ride.startTime))) +
+                              ' ' +
+                              DateFormat('jm').format(widget.ride.startTime),
+                          style: CarriageTheme.largeTitle),
+                    ),
                   ),
                   Container(
                     color: Colors.white,

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -52,7 +52,10 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                     Row(
                       children: <Widget>[
                         Flexible(
-                          child: Text('Location', style: CarriageTheme.title1),
+                          child: Semantics(
+                            header: true,
+                            child: Text('Location', style: CarriageTheme.title1)
+                          ),
                         )
                       ],
                     ),
@@ -257,7 +260,9 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
               child: Container(
                 width: double.infinity,
                 child: Semantics(
-                  label: name + ', ' + address,
+                  button: true,
+                  label: !locationsProvider.isPreset(suggestions[index]) ?
+                    name + ', ' + address : name,
                   child: ExcludeSemantics(
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -265,12 +270,15 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
                           SizedBox(height: 16),
                           Text(name,
                               style: TextStyle(
-                                  fontSize: 15, fontWeight: FontWeight.bold)),
+                                  fontSize: 15, fontWeight: FontWeight.bold
+                              )
+                          ),
                           !locationsProvider.isPreset(suggestions[index])
                               ? Text(address,
                                   style: TextStyle(
-                                      color: Colors.grey, fontSize: 12))
-                              : Container(),
+                                      color: Colors.grey, fontSize: 12
+                                  )
+                          ) : Container(),
                           SizedBox(height: 16),
                         ]),
                   ),
@@ -301,16 +309,19 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
               children: <Widget>[
                 BackText(),
                 SizedBox(height: 20.0),
-                Row(
-                  children: <Widget>[
-                    Flexible(
-                      child: widget.isToLocation
-                          ? Text('Where do you want to be dropped off?',
-                              style: CarriageTheme.title1)
-                          : Text('Where do you want to be picked up?',
-                              style: CarriageTheme.title1),
-                    )
-                  ],
+                Semantics(
+                  header: true,
+                  child: Row(
+                    children: <Widget>[
+                      Flexible(
+                        child: widget.isToLocation
+                            ? Text('Where do you want to be dropped off?',
+                                style: CarriageTheme.title1)
+                            : Text('Where do you want to be picked up?',
+                                style: CarriageTheme.title1),
+                      )
+                    ],
+                  ),
                 ),
                 SizedBox(height: 20.0),
                 LocationField(

--- a/lib/pages/ride-flow/Request_Ride_Loc.dart
+++ b/lib/pages/ride-flow/Request_Ride_Loc.dart
@@ -53,9 +53,9 @@ class _RequestRideLocState extends State<RequestRideLoc> {
                       children: <Widget>[
                         Flexible(
                           child: Semantics(
-                            header: true,
-                            child: Text('Location', style: CarriageTheme.title1)
-                          ),
+                              header: true,
+                              child: Text('Location',
+                                  style: CarriageTheme.title1)),
                         )
                       ],
                     ),
@@ -261,8 +261,9 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
                 width: double.infinity,
                 child: Semantics(
                   button: true,
-                  label: !locationsProvider.isPreset(suggestions[index]) ?
-                    name + ', ' + address : name,
+                  label: !locationsProvider.isPreset(suggestions[index])
+                      ? name + ', ' + address
+                      : name,
                   child: ExcludeSemantics(
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -270,15 +271,12 @@ class _SelectLocationPageState extends State<SelectLocationPage> {
                           SizedBox(height: 16),
                           Text(name,
                               style: TextStyle(
-                                  fontSize: 15, fontWeight: FontWeight.bold
-                              )
-                          ),
+                                  fontSize: 15, fontWeight: FontWeight.bold)),
                           !locationsProvider.isPreset(suggestions[index])
                               ? Text(address,
                                   style: TextStyle(
-                                      color: Colors.grey, fontSize: 12
-                                  )
-                          ) : Container(),
+                                      color: Colors.grey, fontSize: 12))
+                              : Container(),
                           SizedBox(height: 16),
                         ]),
                   ),

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -49,7 +49,8 @@ class _RequestRideTypeState extends State<RequestRideType> {
                   Flexible(
                     child: Semantics(
                         header: true,
-                        child: Text('Date & Time', style: CarriageTheme.title1)),
+                        child:
+                            Text('Date & Time', style: CarriageTheme.title1)),
                   )
                 ],
               ),

--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -47,7 +47,9 @@ class _RequestRideTypeState extends State<RequestRideType> {
               Row(
                 children: <Widget>[
                   Flexible(
-                    child: Text('Date & Time', style: CarriageTheme.title1),
+                    child: Semantics(
+                        header: true,
+                        child: Text('Date & Time', style: CarriageTheme.title1)),
                   )
                 ],
               ),
@@ -395,8 +397,11 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                       Row(
                         children: <Widget>[
                           Flexible(
-                            child: Text('Date & Time',
-                                style: CarriageTheme.title1),
+                            child: Semantics(
+                              header: true,
+                              child: Text('Date & Time',
+                                  style: CarriageTheme.title1),
+                            ),
                           )
                         ],
                       ),
@@ -412,17 +417,23 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                       Row(
                         children: <Widget>[
                           Flexible(
-                            child: Text('When is your ride? (2/2)',
-                                style: CarriageTheme.title1),
+                            child: Semantics(
+                              header: true,
+                              child: Text('When is your ride? (2/2)',
+                                  style: CarriageTheme.title1),
+                            ),
                           )
                         ],
                       ),
                       SizedBox(height: 30.0),
                       Row(
                         children: <Widget>[
-                          Text('Date & Time',
-                              style: TextStyle(
-                                  fontSize: 18, fontWeight: FontWeight.bold)),
+                          Semantics(
+                            header: true,
+                            child: Text('Date & Time',
+                                style: TextStyle(
+                                    fontSize: 18, fontWeight: FontWeight.bold)),
+                          ),
                         ],
                       ),
                       Form(
@@ -486,10 +497,13 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                               SizedBox(height: 30.0),
                               Row(
                                 children: <Widget>[
-                                  Text('Repeat Days',
-                                      style: TextStyle(
-                                          fontSize: 18,
-                                          fontWeight: FontWeight.bold)),
+                                  Semantics(
+                                    header: true,
+                                    child: Text('Repeat Days',
+                                        style: TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.bold)),
+                                  ),
                                 ],
                               ),
                               SizedBox(height: 15),

--- a/lib/pages/ride-flow/Ride_Confirmation.dart
+++ b/lib/pages/ride-flow/Ride_Confirmation.dart
@@ -38,12 +38,15 @@ class _RideConfirmationState extends State<RideConfirmation> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 Expanded(
-                  child: Text(
-                      rideFlowProvider.creating()
-                          ? 'Your request is in progress!'
-                          : 'Your changes are in progress!',
-                      textAlign: TextAlign.center,
-                      style: CarriageTheme.title3),
+                  child: Semantics(
+                    header: true,
+                    child: Text(
+                        rideFlowProvider.creating()
+                            ? 'Your request is in progress!'
+                            : 'Your changes are in progress!',
+                        textAlign: TextAlign.center,
+                        style: CarriageTheme.title3),
+                  ),
                 )
               ],
             ),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements some minor fixes for screenreader accessibility

- [x] added missing button and header semantics
- [x] pulled out drawer menu option widget creator into a function for convenience of adding button semantics
- [x] fixed locations label to exclude address for preset locations

### Test Plan <!-- Required -->

Tested with TalkBack; ideally would also want a quick test with VoiceOver if possible

