### PR TITLE
fixed overflow errors on iPhone SE

### DIFF
--- a/lib/pages/ride-flow/Request_Ride_Time.dart
+++ b/lib/pages/ride-flow/Request_Ride_Time.dart
@@ -510,35 +510,58 @@ class _RequestRideDateTimeState extends State<RequestRideDateTime> {
                               SizedBox(height: 15),
                               Row(
                                 children: [
-                                  ToggleButton(
-                                      rideFlowProvider.repeatDaysSelected[0],
-                                      () => toggle(rideFlowProvider, 0),
-                                      'M',
-                                      'Mondays'),
-                                  SizedBox(width: 15),
-                                  ToggleButton(
-                                      rideFlowProvider.repeatDaysSelected[1],
-                                      () => toggle(rideFlowProvider, 1),
-                                      'T',
-                                      'Tuesdays'),
-                                  SizedBox(width: 15),
-                                  ToggleButton(
-                                      rideFlowProvider.repeatDaysSelected[2],
-                                      () => toggle(rideFlowProvider, 2),
-                                      'W',
-                                      'Wednesdays'),
-                                  SizedBox(width: 15),
-                                  ToggleButton(
-                                      rideFlowProvider.repeatDaysSelected[3],
-                                      () => toggle(rideFlowProvider, 3),
-                                      'Th',
-                                      'Thursdays'),
-                                  SizedBox(width: 15),
-                                  ToggleButton(
-                                      rideFlowProvider.repeatDaysSelected[4],
-                                      () => toggle(rideFlowProvider, 4),
-                                      'F',
-                                      'Fridays'),
+                                  Expanded(
+                                    flex: 5,
+                                    child: ToggleButton(
+                                        rideFlowProvider.repeatDaysSelected[0],
+                                        () => toggle(rideFlowProvider, 0),
+                                        'M',
+                                        'Mondays'),
+                                  ),
+                                  Spacer(
+                                    flex: 2,
+                                  ),
+                                  Expanded(
+                                    flex: 5,
+                                    child: ToggleButton(
+                                        rideFlowProvider.repeatDaysSelected[1],
+                                        () => toggle(rideFlowProvider, 1),
+                                        'T',
+                                        'Tuesdays'),
+                                  ),
+                                  Spacer(
+                                    flex: 2,
+                                  ),
+                                  Expanded(
+                                    flex: 5,
+                                    child: ToggleButton(
+                                        rideFlowProvider.repeatDaysSelected[2],
+                                        () => toggle(rideFlowProvider, 2),
+                                        'W',
+                                        'Wednesdays'),
+                                  ),
+                                  Spacer(
+                                    flex: 2,
+                                  ),
+                                  Expanded(
+                                    flex: 5,
+                                    child: ToggleButton(
+                                        rideFlowProvider.repeatDaysSelected[3],
+                                        () => toggle(rideFlowProvider, 3),
+                                        'Th',
+                                        'Thursdays'),
+                                  ),
+                                  Spacer(
+                                    flex: 2,
+                                  ),
+                                  Expanded(
+                                    flex: 5,
+                                    child: ToggleButton(
+                                        rideFlowProvider.repeatDaysSelected[4],
+                                        () => toggle(rideFlowProvider, 4),
+                                        'F',
+                                        'Fridays'),
+                                  ),
                                 ],
                               ),
                               showSelectionError &&

--- a/lib/widgets/Buttons.dart
+++ b/lib/widgets/Buttons.dart
@@ -14,12 +14,11 @@ class CButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
-          padding: EdgeInsets.all(16),
-          primary: Colors.black,
-          onPrimary: Colors.white,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          fixedSize: Size.fromHeight(height)),
+        padding: EdgeInsets.all(16),
+        primary: Colors.black,
+        onPrimary: Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
       child: Text(text, style: CarriageTheme.button),
       onPressed: onPressed,
     );


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Fixed the overflow errors in iPhone SE. Used Expanded and its flex property as recommended by the console. Also did what Helen Yang's comment in https://github.com/cornell-dti/carriage-rider/pull/88 suggested. 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Tested on iPhone SE and iPhone 12. All buttons appear to be working and no overflow is shown. Might be beneficial to test on other devices as well.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
